### PR TITLE
Adjust saving behavior to require both footswitches to be held

### DIFF
--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -148,7 +148,9 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
     }
 
     //If both footswitches are down, save the parameters for this effect to persistant storage
-    if (hardware.switches[1].TimeHeldMs() > 2000 && !guitarPedalUI.IsShowingSavingSettingsScreen())
+    if (hardware.switches[0].TimeHeldMs() > 2000 &&
+        hardware.switches[1].TimeHeldMs() > 2000 &&
+        !guitarPedalUI.IsShowingSavingSettingsScreen())
     {
         needToSaveSettingsForActiveEffect = true;
     }


### PR DESCRIPTION
This seems to have been the intention and makes sense to me 🤷 Feel free to close if you don't want it!

I could see why someone would prefer the other way, but if so I would probably adjust the comment