### PR TITLE
Fix backwards logic for bool parameters

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/base_effect_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/base_effect_module.cpp
@@ -371,11 +371,11 @@ void BaseEffectModule::SetParameterAsBool(int parameter_id, bool value)
 {
     if (value)
     {
-        SetParameterRaw(parameter_id, GetParameterMin(parameter_id));
+        SetParameterRaw(parameter_id, GetParameterMax(parameter_id));
     }
     else
     {
-        SetParameterRaw(parameter_id, GetParameterMax(parameter_id));
+        SetParameterRaw(parameter_id, GetParameterMin(parameter_id));
     }
     
 }


### PR DESCRIPTION
I think this went unnoticed because I couldn't find anything else in the codebase that mapped ParameterValueType::Bool to a knob, all of them I assume are being set with midi or the UI.

I am using knobs in a few places for settings and the logic was backwards, this fixes it