### PR TITLE
Alternate footswitch usable for (non tempo based) effects easily

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/base_effect_module.h
+++ b/Software/GuitarPedal/Effect-Modules/base_effect_module.h
@@ -255,6 +255,18 @@ class BaseEffectModule
         \param value, midi value
     */
     virtual void MidiCCValueNotification(uint8_t control_num, uint8_t value);
+
+    /** Effect can override this and return false to disable the tap tempo functionality to utilize the switch (loopers, momentary effects, etc)
+     *  \return Value True if the Effect uses the alternate footswitch for tap tempo
+    */
+    virtual bool AlternateFootswitchForTempo() const { return true; };
+    /** Overridable callback when alternate footswitch is pressed */
+    virtual void AlternateFootswitchPressed() {};
+    /** Overridable callback when alternate footswitch is released */
+    virtual void AlternateFootswitchReleased() {};
+    /** Overridable callback when alternate footswitch is held for 1 second */
+    virtual void AlternateFootswitchHeldFor1Second() {};
+
   protected:
     /** Initializes the Parameter Storage and creates space for the specified number of stored Effect Parameters
         \param count  The number of stored parameters

--- a/Software/GuitarPedal/Hardware-Modules/base_hardware_module.h
+++ b/Software/GuitarPedal/Hardware-Modules/base_hardware_module.h
@@ -21,7 +21,7 @@ namespace bkshepherd {
 enum SpecialFunctionType
 {
    Bypass,                    // Bypass
-   TapTempo,                  // TapTempo
+   Alternate,                 // Alternate footswitch for effects to use (by default it is tap tempo if an effect doesn't change it)
    SpecialFunctionType_LAST,  // Last enum item
 };
 
@@ -156,7 +156,7 @@ class BaseHardwareModule
     int GetLedCount();
 
     /**
-       Gets the ID of the Switch this hardware would prefer is used for a specific special function such as Bypass or TapTempo.
+       Gets the ID of the Switch this hardware would prefer is used for a specific special function such as Bypass or TapTempo(Alternate).
        \param sfType The type of special function
        \return The preferred SwitchID for this function. -1 if there is no available switch for this function on this hardware
      */

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_125b.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_125b.cpp
@@ -4,7 +4,7 @@ using namespace bkshepherd;
 
 static const int s_switchParamCount = 2;
 static const PreferredSwitchMetaData s_switchMetaData[s_switchParamCount] = {{sfType: SpecialFunctionType::Bypass, switchMapping: 0},
-                                                                            {sfType: SpecialFunctionType::TapTempo, switchMapping: 1}}; 
+                                                                            {sfType: SpecialFunctionType::Alternate, switchMapping: 1}};
 
 GuitarPedal125B::GuitarPedal125B() : BaseHardwareModule()
 {

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b-SMD.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b-SMD.cpp
@@ -4,7 +4,7 @@ using namespace bkshepherd;
 
 static const int s_switchParamCount = 2;
 static const PreferredSwitchMetaData s_switchMetaData[s_switchParamCount] = {{sfType: SpecialFunctionType::Bypass, switchMapping: 0},
-                                                                            {sfType: SpecialFunctionType::TapTempo, switchMapping: 1}}; 
+                                                                            {sfType: SpecialFunctionType::Alternate, switchMapping: 1}};
 
 GuitarPedal1590BSMD::GuitarPedal1590BSMD() : BaseHardwareModule()
 {

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b.cpp
@@ -4,7 +4,7 @@ using namespace bkshepherd;
 
 static const int s_switchParamCount = 2;
 static const PreferredSwitchMetaData s_switchMetaData[s_switchParamCount] = {{sfType: SpecialFunctionType::Bypass, switchMapping: 0},
-                                                                            {sfType: SpecialFunctionType::TapTempo, switchMapping: 1}}; 
+                                                                            {sfType: SpecialFunctionType::Alternate, switchMapping: 1}};
 
 GuitarPedal1590B::GuitarPedal1590B() : BaseHardwareModule()
 {

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_terrarium.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_terrarium.cpp
@@ -4,7 +4,7 @@ using namespace bkshepherd;
 
 static const int s_switchParamCount = 2;
 static const PreferredSwitchMetaData s_switchMetaData[s_switchParamCount] = {{sfType: SpecialFunctionType::Bypass, switchMapping: 0},
-                                                                            {sfType: SpecialFunctionType::TapTempo, switchMapping: 1}}; 
+                                                                            {sfType: SpecialFunctionType::Alternate, switchMapping: 1}};
 
 GuitarPedalTerrarium::GuitarPedalTerrarium() : BaseHardwareModule()
 {

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -160,6 +160,13 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
     for (int i = 0; i < hardware.GetSwitchCount(); i++)
     {
         bool switchPressed = hardware.switches[i].RisingEdge();
+
+        // Find which hardware switch is mapped to the Effect On/Off Bypass function
+        if (i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Bypass))
+        {
+             effectOn ^= switchPressed;
+        }
+
         if (switchPressed && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
           activeEffect->AlternateFootswitchPressed();
         }
@@ -172,12 +179,6 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
         bool switchHeld = hardware.switches[i].TimeHeldMs() >= 1000.f;
         if (switchHeld && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
           activeEffect->AlternateFootswitchHeldFor1Second();
-        }
-
-        // Find which hardware switch is mapped to the Effect On/Off Bypass function
-        if (i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Bypass))
-        {
-             effectOn ^= switchPressed;
         }
 
         if (switchEnabledCache[i] == true)

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -160,6 +160,19 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
     for (int i = 0; i < hardware.GetSwitchCount(); i++)
     {
         bool switchPressed = hardware.switches[i].RisingEdge();
+        if (switchPressed && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
+          activeEffect->AlternateFootswitchPressed();
+        }
+
+        bool switchReleased = hardware.switches[i].FallingEdge();
+        if (switchReleased && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
+          activeEffect->AlternateFootswitchReleased();
+        }
+
+        bool switchHeld = hardware.switches[i].TimeHeldMs() >= 1000.f;
+        if (switchHeld && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
+          activeEffect->AlternateFootswitchHeldFor1Second();
+        }
 
         // Find which hardware switch is mapped to the Effect On/Off Bypass function
         if (i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Bypass))
@@ -195,7 +208,7 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
                 switchDoubleEnabledCache[i] = true;
 
                 // Register as Tap Tempo if Switch ID matched preferred mapping for TapTempo
-                if (i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::TapTempo))
+                if (!activeEffect->AlternateFootswitchForTempo() && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate))
                 {
                     needToChangeTempo = true;
                     float timeBetweenPresses = hardware.GetTimeForNumberOfSamples(switchEnabledIdleTimeInSamples - switchEnabledSamplesTilIdle[i]);


### PR DESCRIPTION
I personally found this to be useful. I use the alternate footswitch for a looper and also for my digitech style drop/ricochet/whammy pedal

I could probably have just ignored the tap tempo stuff entirely, and read the hw state from my effect, but this seemed a bit cleaner to me.

Let me know what you think, no strong feelings here!