### PR TITLE
Add pitch shifter effect digitech drop/whammy/ricochet

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.cpp
@@ -1,0 +1,231 @@
+#include "pitch_shifter_module.h"
+
+#include <algorithm>
+
+#include "../Util/pitch_shifter.h"
+#include "daisysp.h"
+
+using namespace bkshepherd;
+
+static const char *s_semitoneBinNames[8] = {"0", "1", "2", "3",
+                                            "4", "5", "6", "7"};
+static const char *s_directionBinNames[2] = {"DOWN", "UP"};
+static const char *s_modeBinNames[2] = {"LATCH", "MOMENT"};
+
+// How many samples to delay to based on the "Delay" knob and parameter
+// when the time knob is set to max, this is used for the ramp up/down
+// transition when in momentary mode. Has no effect on latching mode
+const uint32_t k_maxSamplesMaxTime = 48000 * 2;
+
+static const int s_paramCount = 5;
+static const ParameterMetaData s_metaData[s_paramCount] = {
+    {
+      name : "Semitone",
+      valueType : ParameterValueType::Binned,
+      valueBinCount : 8,
+      valueBinNames : s_semitoneBinNames,
+      defaultValue : (127 / 8) * 2,
+      knobMapping : 0,
+      midiCCMapping : -1
+    },
+    {
+      name : "Crossfade",
+      valueType : ParameterValueType::FloatMagnitude,
+      valueBinCount : 0,
+      defaultValue : 127,
+      knobMapping : 1,
+      midiCCMapping : -1
+    },
+    {
+      name : "Direction",
+      valueType : ParameterValueType::Binned,
+      valueBinCount : 2,
+      valueBinNames : s_directionBinNames,
+      defaultValue : 0,
+      knobMapping : 2,
+      midiCCMapping : -1
+    },
+    {
+      name : "Mode",
+      valueType : ParameterValueType::Binned,
+      valueBinCount : 2,
+      valueBinNames : s_modeBinNames,
+      defaultValue : 0,
+      knobMapping : 3,
+      midiCCMapping : -1
+    },
+    {
+      name : "Delay",
+      valueType : ParameterValueType::FloatMagnitude,
+      valueBinCount : 0,
+      defaultValue : 0,
+      knobMapping : 4,
+      midiCCMapping : -1
+    },
+};
+
+// Fixed loud noise at startup (First time after power cycle) by NOT
+// putting this in DSY_SDRAM_BSS
+static daisysp_modified::PitchShifter pitchShifter;
+static daisysp::CrossFade pitchCrossfade;
+
+// Default Constructor
+PitchShifterModule::PitchShifterModule() : BaseEffectModule() {
+  m_name = "Pitch";
+
+  // Setup the meta data reference for this Effect
+  m_paramMetaData = s_metaData;
+
+  // Initialize Parameters for this Effect
+  this->InitParams(s_paramCount);
+}
+
+// Destructor
+PitchShifterModule::~PitchShifterModule() {}
+
+void PitchShifterModule::Init(float sample_rate) {
+  BaseEffectModule::Init(sample_rate);
+
+  pitchShifter.Init(sample_rate);
+
+  pitchCrossfade.Init(CROSSFADE_CPOW);
+  pitchCrossfade.SetPos(GetParameterAsMagnitude(1));
+
+  m_latching = GetParameterAsBinnedValue(3) == 1;
+
+  m_directionDown = GetParameterAsBinnedValue(2) == 1;
+  if (m_directionDown) {
+    m_semitoneTarget = (GetParameterAsBinnedValue(0) - 1) * -1.0f;
+  } else {
+    m_semitoneTarget = (GetParameterAsBinnedValue(0) - 1);
+  }
+  pitchShifter.SetTransposition(m_semitoneTarget);
+
+  m_delayValue = GetParameterAsMagnitude(4);
+}
+
+void PitchShifterModule::ParameterChanged(int parameter_id) {
+  if (parameter_id == 0 || parameter_id == 2) {
+    // Change semitone when semitone knob is turned or direction is changed
+    m_directionDown = GetParameterAsBinnedValue(2) == 1;
+    if (m_directionDown) {
+      m_semitoneTarget = (GetParameterAsBinnedValue(0) - 1) * -1.0f;
+    } else {
+      m_semitoneTarget = (GetParameterAsBinnedValue(0) - 1);
+    }
+  } else if (parameter_id == 1) {
+    pitchCrossfade.SetPos(GetParameterAsMagnitude(1));
+  } else if (parameter_id == 3) {
+    m_latching = GetParameterAsBinnedValue(3) == 1;
+  } else if (parameter_id == 4) {
+    m_delayValue = GetParameterAsMagnitude(4);
+  }
+
+  // Parameters changed, reset the transposition target just in case (mostly
+  // impacts momentary/latch and delay)
+  pitchShifter.SetTransposition(m_semitoneTarget);
+}
+
+void PitchShifterModule::AlternateFootswitchPressed() {
+  m_alternateFootswitchPressed = true;
+
+  if (!m_latching && m_sampleCounter == 0) {
+    // Initiate the ramp up transition for momentary mode
+    m_sampleCounter += 1;
+  }
+}
+
+void PitchShifterModule::AlternateFootswitchReleased() {
+  m_alternateFootswitchPressed = false;
+
+  if (!m_latching && m_sampleCounter > 0) {
+    // Initiate the ramp down transition for momentary mode
+    m_sampleCounter -= 1;
+  }
+}
+
+void PitchShifterModule::ProcessMono(float in) {
+  float out = in;
+
+  if (m_latching) {
+    // When in latching mode, just process the target semitone at all times
+    // immediately
+    float shifted = pitchShifter.Process(in);
+    out = pitchCrossfade.Process(in, shifted);
+  } else {
+    out = ProcessMomentaryMode(in);
+  }
+
+  m_audioRight = m_audioLeft = out;
+}
+
+void PitchShifterModule::ProcessStereo(float inL, float inR) {
+  ProcessMono(inL);
+}
+
+float clamp(float v, float min, float max) {
+  return std::min(max, std::max(min, v));
+}
+
+float PitchShifterModule::ProcessMomentaryMode(float in) {
+  // When in momentary mode, there is a ramp up(pressed)/ramp down(released)
+  // transition of the semitone based on the "delay" parameter
+  const uint32_t samplesToDelay = static_cast<uint32_t>(
+      static_cast<float>(k_maxSamplesMaxTime) * m_delayValue);
+
+  // Are we still in the middle or starting a "ramp up/ramp down
+  // period" where we are transitioning to/from a target semitone
+  const bool transitioning = m_sampleCounter > 0 && samplesToDelay > 0;
+
+  // ---- Process when NOT in a ramp up/ramp down state ----
+  if (!transitioning) {
+    if (m_alternateFootswitchPressed) {
+      // If the footswitch IS pressed, we maintain the m_sampleCounter value
+      // where it was to use for the ramp down
+
+      // Process the pitch shift for completely active to the target
+      pitchShifter.SetTransposition(m_semitoneTarget);
+      float shifted = pitchShifter.Process(in);
+      float out = pitchCrossfade.Process(in, shifted);
+      return out;
+    } else {
+      // If the footswitch isn't pressed, reset values for next ramp up
+      // Make sure the crossfader is initialized and the sample counter is
+      // ready for the next ramp up transition time
+      m_sampleCounter = 0;
+
+      // Return the input directly since the switch isn't pressed and we aren't
+      // ramping down
+
+      // Process the pitch shift for completely inactive (0)
+      pitchShifter.SetTransposition(0);
+      float shifted = pitchShifter.Process(in);
+      float out = pitchCrossfade.Process(in, shifted);
+      return out;
+    }
+  }
+
+  // ---- Process ramp up/ramp down transition ----
+
+  // Clamp just to make sure we don't overshoot the semitone just in case
+  const float percentageComplete = clamp(
+      static_cast<float>(m_sampleCounter) / static_cast<float>(samplesToDelay),
+      0.0f, 1.0f);
+
+  // Perform the pitch shift
+  pitchShifter.SetTransposition(m_semitoneTarget * percentageComplete);
+  float shifted = pitchShifter.Process(in);
+  float pitchOut = pitchCrossfade.Process(in, shifted);
+
+  const bool transitioningTowardsSemitoneTarget = m_alternateFootswitchPressed;
+
+  // Increment or decrement the counter for the next pass through based on if
+  // we are ramping up or ramping down and complete or not
+  if (transitioningTowardsSemitoneTarget && m_sampleCounter < samplesToDelay) {
+    m_sampleCounter += 1;
+  } else if (!transitioningTowardsSemitoneTarget && m_sampleCounter > 0) {
+    m_sampleCounter -= 1;
+  }
+
+  return pitchOut;
+}

--- a/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.h
+++ b/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.h
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef PITCH_SHIFTER_MODULE_H
+#define PITCH_SHIFTER_MODULE_H
+
+#include <stdint.h>
+
+#include "base_effect_module.h"
+#ifdef __cplusplus
+
+/** @file pitch_shifter_module.h */
+
+namespace bkshepherd {
+
+class PitchShifterModule : public BaseEffectModule {
+ public:
+  PitchShifterModule();
+  ~PitchShifterModule();
+
+  void Init(float sample_rate) override;
+  void ProcessMono(float in) override;
+  void ProcessStereo(float inL, float inR) override;
+  void ParameterChanged(int parameter_id) override;
+
+  bool AlternateFootswitchForTempo() const override { return false; }
+  void AlternateFootswitchPressed() override;
+  void AlternateFootswitchReleased() override;
+
+ private:
+  float ProcessMomentaryMode(float in);
+
+  bool m_latching = true;
+  bool m_directionDown = true;
+  bool m_alternateFootswitchPressed = false;
+
+  float m_semitoneTarget = 0;
+
+  float m_delayValue = 0;
+  uint32_t m_sampleCounter = 0;
+};
+}  // namespace bkshepherd
+#endif
+#endif

--- a/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.h
+++ b/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.h
@@ -24,9 +24,13 @@ class PitchShifterModule : public BaseEffectModule {
   bool AlternateFootswitchForTempo() const override { return false; }
   void AlternateFootswitchPressed() override;
   void AlternateFootswitchReleased() override;
+  void DrawUI(OneBitGraphicsDisplay &display, int currentIndex,
+              int numItemsTotal, Rectangle boundsToDrawIn,
+              bool isEditing) override;
 
  private:
   float ProcessMomentaryMode(float in);
+  void ProcessSemitoneTargetChange();
 
   bool m_latching = true;
   bool m_directionDown = true;
@@ -36,6 +40,8 @@ class PitchShifterModule : public BaseEffectModule {
 
   float m_delayValue = 0;
   uint32_t m_sampleCounter = 0;
+
+  float m_percentageTransitionComplete = 0.0;
 };
 }  // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.h
+++ b/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.h
@@ -38,8 +38,12 @@ class PitchShifterModule : public BaseEffectModule {
 
   float m_semitoneTarget = 0;
 
-  float m_delayValue = 0;
   uint32_t m_sampleCounter = 0;
+  uint32_t m_samplesToDelayShift = 0;
+  uint32_t m_samplesToDelayReturn = 0;
+
+  bool m_transitioningShift = false;
+  bool m_transitioningReturn = false;
 
   float m_percentageTransitionComplete = 0.0;
 };

--- a/Software/GuitarPedal/Util/phasor.h
+++ b/Software/GuitarPedal/Util/phasor.h
@@ -1,0 +1,79 @@
+// This is a copy of the phasor from DaisySP with this PR applied:
+// https://github.com/electro-smith/DaisySP/pull/166
+// This file can be deleted if that PR is merged and the submodule is updated
+
+#pragma once
+#ifndef PHASOR_H
+#define PHASOR_H
+#ifdef __cplusplus
+
+#define PI_F 3.1415927410125732421875f
+#define TWOPI_F (2.0f * PI_F)
+
+namespace daisysp_modified {
+/** Generates a normalized signal moving from 0-1 at the specified frequency.
+
+\todo Selecting which channels should be initialized/included in the sequence
+conversion. \todo Setup a similar start function for an external mux, but that
+seems outside the scope of this file.
+
+*/
+class Phasor {
+ public:
+  Phasor() {}
+  ~Phasor() {}
+  /** Initializes the Phasor module
+  sample rate, and freq are in Hz
+  initial phase is in radians
+  Additional Init functions have defaults when arg is not specified:
+  - phs = 0.0f
+  - freq = 1.0f
+  */
+  inline void Init(float sample_rate, float freq, float initial_phase) {
+    sample_rate_ = sample_rate;
+    phs_ = initial_phase;
+    SetFreq(freq);
+  }
+
+  /** Initialize phasor with samplerate and freq
+   */
+  inline void Init(float sample_rate, float freq) {
+    Init(sample_rate, freq, 0.0f);
+  }
+
+  /** Initialize phasor with samplerate
+   */
+  inline void Init(float sample_rate) { Init(sample_rate, 1.0f, 0.0f); }
+  /** processes Phasor and returns current value
+   */
+  float Process() {
+    float out;
+    out = phs_ / TWOPI_F;
+    phs_ += inc_;
+    if (phs_ > TWOPI_F) {
+      phs_ -= TWOPI_F;
+    }
+    if (phs_ < 0.0f) {
+      phs_ += TWOPI_F;
+    }
+    return out;
+  }
+
+  /** Sets frequency of the Phasor in Hz
+   */
+  void SetFreq(float freq) {
+    freq_ = freq;
+    inc_ = (TWOPI_F * freq_) / sample_rate_;
+  }
+
+  /** Returns current frequency value in Hz
+   */
+  inline float GetFreq() { return freq_; }
+
+ private:
+  float freq_;
+  float sample_rate_, inc_, phs_;
+};
+}  // namespace daisysp_modified
+#endif
+#endif

--- a/Software/GuitarPedal/Util/pitch_shifter.h
+++ b/Software/GuitarPedal/Util/pitch_shifter.h
@@ -1,6 +1,9 @@
 // This is a copy of the pitch_shifter from DaisySP with this PR applied:
 // https://github.com/electro-smith/DaisySP/pull/166
-// This file can be deleted if that PR is merged and the submodule is updated
+// The buffer size is also changed to minimize latency
+// static constexpr size_t kShiftDelaySize = 2048;
+// This file can be deleted if that PR is merged, the buffer size is templatized
+// or parameterized, and the submodule is updated
 
 #pragma once
 #ifndef PITCHSHIFTER_H

--- a/Software/GuitarPedal/Util/pitch_shifter.h
+++ b/Software/GuitarPedal/Util/pitch_shifter.h
@@ -1,0 +1,184 @@
+// This is a copy of the pitch_shifter from DaisySP with this PR applied:
+// https://github.com/electro-smith/DaisySP/pull/166
+// This file can be deleted if that PR is merged and the submodule is updated
+
+#pragma once
+#ifndef PITCHSHIFTER_H
+#define PITCHSHIFTER_H
+#include <stdint.h>
+
+#include <cmath>
+#ifdef USE_ARM_DSP
+#include "arm_math.h"
+#endif
+#include "Utility/delayline.h"
+#include "Utility/dsp.h"
+#include "phasor.h"
+
+using namespace daisysp;
+
+namespace daisysp_modified {
+static inline uint32_t hash_xs32(uint32_t x) {
+  x ^= x << 13;
+  x ^= x >> 17;
+  x ^= x << 5;
+  return x;
+}
+
+inline uint32_t myrand() {
+  static uint32_t seed = 1;
+  seed = hash_xs32(seed);
+  return seed;
+}
+
+/**  time-domain pitchshifter
+
+Author: shensley
+
+Based on "Pitch Shifting" from ucsd.edu
+
+t = 1 - ((s *f) / R)
+
+where:
+    s is the size of the delay
+    f is the frequency of the lfo
+    r is the sample_rate
+
+solving for t = 12.0
+f = (12 - 1) * 48000 / kShiftDelaySize;
+
+\todo - move hash_xs32 and myrand to dsp.h and give appropriate names
+*/
+class PitchShifter {
+ public:
+  PitchShifter() {}
+  ~PitchShifter() {}
+
+  /** Initialize pitch shifter
+   *  \param sr the expected samplerate in Hz of the audio engines
+   *  \param quantize_semitones locks transpositions to integer values (defaults
+   * to false)
+   */
+  void Init(float sr, bool quantize_semitones = false) {
+    force_recalc_ = false;
+    sr_ = sr;
+    mod_freq_ = 5.0f;
+    for (uint8_t i = 0; i < 2; i++) {
+      gain_[i] = 0.0f;
+      d_[i].Init();
+      phs_[i].Init(sr, 50, i == 0 ? 0 : PI_F);
+    }
+    del_size_ = kShiftDelaySize;
+    SetDelSize(del_size_);
+    fun_ = 0.0f;
+    quantize_semitones_ = quantize_semitones;
+  }
+
+  /** process pitch shifter
+   */
+  float Process(float in) {
+    float val, fade1, fade2;
+    // First Process delay mod/crossfade
+    fade1 = phs_[0].Process();
+    fade2 = phs_[1].Process();
+    bool recalc_a_fun = ((transpose_ >= 0.f) && (prev_phs_a_ > fade1)) ||
+                        ((transpose_ < 0.f) && prev_phs_a_ < fade1);
+    bool recalc_b_fun = ((transpose_ >= 0.f) && (prev_phs_b_ > fade2)) ||
+                        ((transpose_ < 0.f) && prev_phs_b_ < fade2);
+    // Randomly trigger mod recalc when tranpose is 0 so that the "fun"
+    // parameter still does something when not transposing
+    bool rand_retrig = (transpose_ >= -0.25f && transpose_ < 0.25f);
+    if (rand_retrig && fun_ > 0.f)
+      if (myrand() % 65536 < 4) recalc_a_fun = recalc_b_fun = true;
+    if (recalc_a_fun) {
+      mod_a_amt_ =
+          fun_ * ((float)(myrand() % 255) / 255.0f) * (del_size_ * 0.5f);
+      mod_coeff_[0] = 0.0002f + (((float)(myrand() % 255) / 255.0f) * 0.001f);
+    }
+    if (recalc_b_fun) {
+      mod_b_amt_ =
+          fun_ * ((float)(myrand() % 255) / 255.0f) * (del_size_ * 0.5f);
+      mod_coeff_[1] = 0.0002f + (((float)(myrand() % 255) / 255.0f) * 0.001f);
+    }
+    slewed_mod_[0] += mod_coeff_[0] * (mod_a_amt_ - slewed_mod_[0]);
+    slewed_mod_[1] += mod_coeff_[1] * (mod_b_amt_ - slewed_mod_[1]);
+    prev_phs_a_ = fade1;
+    prev_phs_b_ = fade2;
+    fade1 = 1.0f - fade1;
+    fade2 = 1.0f - fade2;
+    mod_[0] = fade1 * (del_size_ - 1);
+    mod_[1] = fade2 * (del_size_ - 1);
+#ifdef USE_ARM_DSP
+    gain_[0] = arm_sin_f32(fade1 * (float)M_PI);
+    gain_[1] = arm_sin_f32(fade2 * (float)M_PI);
+#else
+    gain_[0] = sinf(fade1 * PI_F);
+    gain_[1] = sinf(fade2 * PI_F);
+#endif
+
+    // Handle Delay Writing
+    d_[0].Write(in);
+    d_[1].Write(in);
+    // Modulate Delay Lines
+    // d_[0].SetDelay(mod_[0] + mod_a_amt_);
+    // d_[1].SetDelay(mod_[1] + mod_b_amt_);
+    d_[0].SetDelay(mod_[0] + slewed_mod_[0]);
+    d_[1].SetDelay(mod_[1] + slewed_mod_[1]);
+    val = 0.0f;
+    val += (d_[0].Read() * gain_[0]);
+    val += (d_[1].Read() * gain_[1]);
+    return val;
+  }
+
+  /** sets transposition in semitones
+   */
+  void SetTransposition(const float &transpose) {
+    float ratio;
+    if (transpose_ != transpose || force_recalc_) {
+      transpose_ = quantize_semitones_ ? (int32_t)transpose : transpose;
+      ratio = pow(2.f, transpose_ / 12.f);
+      mod_freq_ = ((ratio - 1.0f) * sr_) / del_size_;
+      phs_[0].SetFreq(mod_freq_);
+      phs_[1].SetFreq(mod_freq_);
+      if (force_recalc_) {
+        force_recalc_ = false;
+      }
+    }
+  }
+
+  /** sets delay size changing the timbre of the pitchshifting
+   */
+  void SetDelSize(uint32_t size) {
+    del_size_ = size < kShiftDelaySize ? size : kShiftDelaySize;
+    force_recalc_ = true;
+    SetTransposition(transpose_);
+  }
+
+  /** sets an amount of internal random modulation, kind of sounds like
+   * tape-flutter
+   */
+  inline void SetFun(float f) { fun_ = f; }
+
+ private:
+  /** Shift can be 30-100 ms lets just start with 50 for now.
+  0.050 * SR = 2400 samples (at 48kHz) */
+  // static constexpr size_t kShiftDelaySize = 16384;
+  static constexpr size_t kShiftDelaySize = 2048;
+  typedef DelayLine<float, kShiftDelaySize> ShiftDelay;
+  ShiftDelay d_[2];
+  float pitch_shift_, mod_freq_;
+  uint32_t del_size_;
+  /** lfo stuff */
+  bool force_recalc_;
+  float sr_;
+  daisysp_modified::Phasor phs_[2];
+  float gain_[2], mod_[2], transpose_;
+  float fun_, mod_a_amt_, mod_b_amt_, prev_phs_a_, prev_phs_b_;
+  float slewed_mod_[2], mod_coeff_[2];
+
+  /** Config stuff */
+  bool quantize_semitones_;
+};
+}  // namespace daisysp_modified
+
+#endif

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -11,6 +11,7 @@
 #include "Effect-Modules/reverb_module.h"
 #include "Effect-Modules/metro_module.h"
 #include "Effect-Modules/multi_delay_module.h"
+#include "Effect-Modules/pitch_shifter_module.h"
 
 
 #include "UI/guitar_pedal_ui.h"
@@ -491,7 +492,7 @@ int main(void)
     crossFaderTransitionTimeInSamples = hardware.GetNumberOfSamplesForTime(crossFaderTransitionTimeInSeconds);
 
     // Init the Effects Modules
-    availableEffectsCount = 8;
+    availableEffectsCount = 9;
     availableEffects = new BaseEffectModule*[availableEffectsCount];
     availableEffects[0] = new ModulatedTremoloModule();
     availableEffects[1] = new OverdriveModule();
@@ -501,6 +502,7 @@ int main(void)
     availableEffects[5] = new ReverbModule();
     availableEffects[6] = new MultiDelayModule();
     availableEffects[7] = new MetroModule();
+    availableEffects[8] = new PitchShifterModule();
 
     
     for (int i = 0; i < availableEffectsCount; i++)


### PR DESCRIPTION
This would be a clean-ish PR if DaisySP merged the PR https://github.com/electro-smith/DaisySP/pull/166 and parameterized the buffer size

I wanted to at least document this in case anyone else is interested since this PR runs quite nicely as is

The knobs are mapped to:

- Set transpose semitone 1,2,3,4,5,6,7, or a full octave
- Crossfade to mix in dry signal
- Set transpose direction Up/Down
- Set mode between Latched/Momentary
- Set shift time (time it takes to get TO the transpose target)
- Set return time (time it takes to get back to no-transpose from the target)

There is a UI when in momentary mode that shows shift/return status.

I mostly will either use this latched/dropped 1 semitone for Eb tuning. Beyond that can start to sound a little off IMO. Momentary mode is also really fun and can make some super interesting stuff, I have used this the most so far just because of how fun it is.