### PR TITLE
Add tuner quick switch to/from by holding bypass for 2 seconds

### DIFF
--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -522,10 +522,10 @@ int main(void)
     availableEffects[5] = new ReverbModule();
     availableEffects[6] = new MultiDelayModule();
     availableEffects[7] = new MetroModule();
-    availableEffects[8] = new PitchShifterModule();
-    availableEffects[9] = new CompressorModule();
-    availableEffects[10] = new LooperModule();
-    availableEffects[11] = new TunerModule();
+    availableEffects[8] = new TunerModule();
+    availableEffects[9] = new PitchShifterModule();
+    availableEffects[10] = new CompressorModule();
+    availableEffects[11] = new LooperModule();
 
     for (int i = 0; i < availableEffectsCount; i++)
     {
@@ -686,7 +686,7 @@ int main(void)
           }
           quickSwitchAvailable = false;
         }
-        
+
         // Disable quick switching until the footswitch is released to prevent
         // infinite switching
         if (!quickSwitchAvailable &&

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -175,8 +175,6 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
     // Process the switches
     for (int i = 0; i < hardware.GetSwitchCount(); i++)
     {
-        bool switchPressed = hardware.switches[i].RisingEdge();
-
         // If bypass is held for 2 seconds and alternate footswitch is not
         // pressed (not trying to save) then quick switch to/from the tuner
         if (tunerModuleIndex > 0 && !ignoreBypassSwitchUntilNextActuation &&
@@ -219,11 +217,13 @@ static void AudioCallback(AudioHandle::InputBuffer  in,
           ignoreBypassSwitchUntilNextActuation = false;
         }
 
+        bool switchPressed = hardware.switches[i].RisingEdge();
+
         // Find which hardware switch is mapped to the Effect On/Off Bypass function
         if (!ignoreBypassSwitchUntilNextActuation &&
             i == hardware.GetPreferredSwitchIDForSpecialFunctionType(
                      SpecialFunctionType::Bypass)) {
-          effectOn ^= switchPressed;
+            effectOn ^= switchPressed;
         }
 
         if (effectOn && switchPressed &&
@@ -714,7 +714,6 @@ int main(void)
             }
             SetActiveEffect(desiredIndex);
         }
-
 
         if (hardware.SupportsDisplay())
         {

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -33,6 +33,7 @@ PersistentStorage<Settings> storage(hardware.seed.qspi);
 int availableEffectsCount = 0;
 BaseEffectModule **availableEffects = NULL;
 int activeEffectID = 0;
+int prevActiveEffectID = 0;
 BaseEffectModule *activeEffect = NULL;
 
 // UI Related Variables
@@ -58,7 +59,10 @@ float secondsSinceStartup = 0.0f;
 bool needToSaveSettingsForActiveEffect = false;
 uint32_t last_save_time;        // Time we last set it
 
-uint32_t last_effect_change_time; // Time we last changed effect
+// Used to debounce quick switching to/from the tuner
+bool quickSwitchAvailable = true;
+// Time we last changed effect
+uint32_t last_effect_change_time;
 
 // Pot Monitoring Variables
 bool knobValuesInitialized = false;
@@ -374,6 +378,9 @@ void SetActiveEffect(int effectID)
 {
     if (effectID >= 0 && effectID < availableEffectsCount)
     {
+        // Store the last used effect
+        prevActiveEffectID = activeEffectID;
+
         // Update the ID cache
         activeEffectID = effectID;
 
@@ -504,7 +511,7 @@ int main(void)
     crossFaderTransitionTimeInSamples = hardware.GetNumberOfSamplesForTime(crossFaderTransitionTimeInSeconds);
 
     // Init the Effects Modules
-    availableEffectsCount = 12;
+    availableEffectsCount = 11;
     availableEffects = new BaseEffectModule*[availableEffectsCount];
     availableEffects[0] = new ModulatedTremoloModule();
     availableEffects[1] = new OverdriveModule();
@@ -514,10 +521,18 @@ int main(void)
     availableEffects[5] = new ReverbModule();
     availableEffects[6] = new MultiDelayModule();
     availableEffects[7] = new MetroModule();
-    availableEffects[8] = new TunerModule();
-    availableEffects[9] = new PitchShifterModule();
-    availableEffects[10] = new CompressorModule();
-    availableEffects[11] = new LooperModule();
+    availableEffects[8] = new PitchShifterModule();
+    availableEffects[9] = new CompressorModule();
+    availableEffects[10] = new LooperModule();
+    /*
+      Most modules should go here and availableEffectsCount should be updated accordingly
+    */
+
+    // Tuner should be last so that it is easy to keep a static index for it, we
+    // can then use the "last index" to quick
+    // switch between the last used effect and the tuner when we want to, also this can be commented out easily to remove the tuner
+    availableEffectsCount += 1;
+    availableEffects[availableEffectsCount - 1] = new TunerModule();
     
     for (int i = 0; i < availableEffectsCount; i++)
     {
@@ -652,6 +667,32 @@ int main(void)
                 desiredIndex = availableEffectsCount - 1;
             }
             SetActiveEffect(desiredIndex);
+        }
+
+        // If bypass is held for 2 seconds and alternate footswitch is not pressed (not trying to save) then quick
+        // switch to/from the tuner
+        if (quickSwitchAvailable &&
+            hardware.switches[hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Bypass)]
+                    .TimeHeldMs() > 2000 &&
+            !hardware.switches[hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)]
+                 .Pressed())
+        {
+            if (activeEffectID == availableEffectsCount - 1)
+            {
+                SetActiveEffect(prevActiveEffectID);
+            }
+            else
+            {
+                SetActiveEffect(availableEffectsCount - 1);
+            }
+            quickSwitchAvailable = false;
+        }
+        // Disable quick switching until the footswitch is released to prevent infinite switching
+        if (!quickSwitchAvailable &&
+            !hardware.switches[hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Bypass)]
+                 .Pressed())
+        {
+            quickSwitchAvailable = true;
         }
 
         if (hardware.SupportsDisplay())


### PR DESCRIPTION
- Hold bypass for 2 seconds and it switches to tuner (active and enabled with LEDs showing that)
- Hold bypass for 2 seconds while on tuner, and it switches back and resumes the enabled state from before you pressed the button