### PR TITLE
Allow showing CPU on the default UI

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/base_effect_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/base_effect_module.cpp
@@ -1,6 +1,9 @@
 #include "base_effect_module.h"
 #include "../Util/audio_utilities.h"
 
+// This can be used to show the CPU on the default UI
+constexpr bool showCPU = false;
+
 using namespace bkshepherd;
 
 // Default Constructor
@@ -469,4 +472,10 @@ void BaseEffectModule::DrawUI(OneBitGraphicsDisplay &display, int currentIndex, 
 
     display.WriteStringAligned(m_name, Font_11x18, topRowRect, Alignment::centered, true);
     display.WriteStringAligned("...", Font_11x18, boundsToDrawIn, Alignment::centered, true);
+
+    if (showCPU) {
+        char cpuStr[64];
+        sprintf(cpuStr, FLT_FMT(3), FLT_VAR3(GetCPUUsage()));
+        display.WriteStringAligned(cpuStr, Font_11x18, boundsToDrawIn, Alignment::bottomCentered, true);
+    }
 }

--- a/Software/GuitarPedal/Effect-Modules/base_effect_module.h
+++ b/Software/GuitarPedal/Effect-Modules/base_effect_module.h
@@ -302,11 +302,14 @@ class BaseEffectModule {
      */
     virtual bool AlternateFootswitchForTempo() const { return true; };
     /** Overridable callback when alternate footswitch is pressed */
-    virtual void AlternateFootswitchPressed(){};
+    virtual void AlternateFootswitchPressed() {};
     /** Overridable callback when alternate footswitch is released */
-    virtual void AlternateFootswitchReleased(){};
+    virtual void AlternateFootswitchReleased() {};
     /** Overridable callback when alternate footswitch is held for 1 second */
-    virtual void AlternateFootswitchHeldFor1Second(){};
+    virtual void AlternateFootswitchHeldFor1Second() {};
+
+    void SetCPUUsage(float cpuUsage) { m_cpuUsage = cpuUsage; };
+    float GetCPUUsage() const { return m_cpuUsage; }
 
   protected:
     /** Initializes the Parameter Storage and creates space for the specified number of stored Effect Parameters
@@ -335,6 +338,7 @@ class BaseEffectModule {
   private:
     bool m_isEnabled;
     float m_sampleRate; // Current Sample Rate this Effect was initialized for.
+    float m_cpuUsage;   // CPU usage of the audio callback, can be used for rendering to display
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Hardware-Modules/base_hardware_module.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/base_hardware_module.cpp
@@ -11,12 +11,12 @@ BaseHardwareModule::BaseHardwareModule()
 
 BaseHardwareModule::~BaseHardwareModule() {}
 
-void BaseHardwareModule::Init(bool boost) {
+void BaseHardwareModule::Init(size_t blockSize, bool boost) {
     // Initialize the hardware.
     seed.Configure();
     seed.Init(boost);
 
-    SetAudioBlockSize(48);
+    SetAudioBlockSize(blockSize);
 }
 
 void BaseHardwareModule::DelayMs(size_t del) { seed.DelayMs(del); }

--- a/Software/GuitarPedal/Hardware-Modules/base_hardware_module.h
+++ b/Software/GuitarPedal/Hardware-Modules/base_hardware_module.h
@@ -41,7 +41,7 @@ class BaseHardwareModule {
     virtual ~BaseHardwareModule();
 
     /** Initialize the pedal */
-    virtual void Init(bool boost = false);
+    virtual void Init(size_t blockSize, bool boost);
 
     /**
        Wait before moving on.

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_125b.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_125b.cpp
@@ -14,8 +14,8 @@ GuitarPedal125B::GuitarPedal125B() : BaseHardwareModule() {
 
 GuitarPedal125B::~GuitarPedal125B() {}
 
-void GuitarPedal125B::Init(bool boost) {
-    BaseHardwareModule::Init(boost);
+void GuitarPedal125B::Init(size_t blockSize, bool boost) {
+    BaseHardwareModule::Init(blockSize, boost);
 
     m_supportsStereo = true;
 

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_125b.h
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_125b.h
@@ -19,7 +19,7 @@ class GuitarPedal125B : public BaseHardwareModule {
   public:
     GuitarPedal125B();
     ~GuitarPedal125B();
-    void Init(bool boost = false) override;
+    void Init(size_t blockSize, bool boost) override;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b-SMD.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b-SMD.cpp
@@ -14,8 +14,8 @@ GuitarPedal1590BSMD::GuitarPedal1590BSMD() : BaseHardwareModule() {
 
 GuitarPedal1590BSMD::~GuitarPedal1590BSMD() {}
 
-void GuitarPedal1590BSMD::Init(bool boost) {
-    BaseHardwareModule::Init(boost);
+void GuitarPedal1590BSMD::Init(size_t blockSize, bool boost) {
+    BaseHardwareModule::Init(blockSize, boost);
 
     m_supportsStereo = true;
 

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b-SMD.h
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b-SMD.h
@@ -19,7 +19,7 @@ class GuitarPedal1590BSMD : public BaseHardwareModule {
   public:
     GuitarPedal1590BSMD();
     ~GuitarPedal1590BSMD();
-    void Init(bool boost = false) override;
+    void Init(size_t blockSize, bool boost) override;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b.cpp
@@ -14,8 +14,8 @@ GuitarPedal1590B::GuitarPedal1590B() : BaseHardwareModule() {
 
 GuitarPedal1590B::~GuitarPedal1590B() {}
 
-void GuitarPedal1590B::Init(bool boost) {
-    BaseHardwareModule::Init(boost);
+void GuitarPedal1590B::Init(size_t blockSize, bool boost) {
+    BaseHardwareModule::Init(blockSize, boost);
 
     m_supportsStereo = true;
 

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b.h
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_1590b.h
@@ -19,7 +19,7 @@ class GuitarPedal1590B : public BaseHardwareModule {
   public:
     GuitarPedal1590B();
     ~GuitarPedal1590B();
-    void Init(bool boost = false) override;
+    void Init(size_t blockSize, bool boost) override;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_terrarium.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_terrarium.cpp
@@ -14,8 +14,8 @@ GuitarPedalTerrarium::GuitarPedalTerrarium() : BaseHardwareModule() {
 
 GuitarPedalTerrarium::~GuitarPedalTerrarium() {}
 
-void GuitarPedalTerrarium::Init(bool boost) {
-    BaseHardwareModule::Init(boost);
+void GuitarPedalTerrarium::Init(size_t blockSize, bool boost) {
+    BaseHardwareModule::Init(blockSize, boost);
 
     Pin knobPins[] = {seed::D16, seed::D17, seed::D18, seed::D19, seed::D20, seed::D21};
     InitKnobs(6, knobPins);

--- a/Software/GuitarPedal/Hardware-Modules/guitar_pedal_terrarium.h
+++ b/Software/GuitarPedal/Hardware-Modules/guitar_pedal_terrarium.h
@@ -19,7 +19,7 @@ class GuitarPedalTerrarium : public BaseHardwareModule {
   public:
     GuitarPedalTerrarium();
     ~GuitarPedalTerrarium();
-    void Init(bool boost = false) override;
+    void Init(size_t blockSize, bool boost) override;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Makefile
+++ b/Software/GuitarPedal/Makefile
@@ -62,15 +62,17 @@ USE_DAISYSP_LGPL=1
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
 include $(SYSTEM_FILES_DIR)/Makefile
 
-C_INCLUDES += -I./dependencies/q/q/q_lib/include
-C_INCLUDES += -I./dependencies/q/infra/include 
-C_INCLUDES += -I./dependencies/gcem/include
-C_INCLUDES += -I./dependencies/eigen
-C_INCLUDES += -I./dependencies/RTNeural
+# Included as system instead of regular includes to avoid warnings from the
+# 3rd party dependencies
+C_INCLUDES += -isystem ./dependencies/q/q/q_lib/include
+C_INCLUDES += -isystem ./dependencies/q/infra/include
+C_INCLUDES += -isystem ./dependencies/gcem/include
+C_INCLUDES += -isystem ./dependencies/eigen
+C_INCLUDES += -isystem ./dependencies/RTNeural
 
 CPPFLAGS += -DRTNEURAL_DEFAULT_ALIGNMENT=8 -DRTNEURAL_NO_DEBUG=1 -DRTNEURAL_USE_EIGEN=1
 
-C_INCLUDES += -I./dependencies/CloudSeed
+C_INCLUDES += -isystem ./dependencies/CloudSeed
 LIBS += -lcloudseed
 LIBDIR += -Ldependencies/CloudSeed/build
 

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -553,10 +553,15 @@ void HandleMidiMessage(MidiEvent m) {
 }
 
 int main(void) {
-    hardware.Init(true); // true enables cpu boost (480Mhz instead of 400Mhz)
-    hardware.SetAudioBlockSize(48);
+    const size_t blockSize = 48;
+    const bool boost = true; // true enables cpu boost (480Mhz instead of 400Mhz)
 
-    float sample_rate = hardware.AudioSampleRate();
+    hardware.Init(blockSize, boost);
+
+    const float sample_rate = hardware.AudioSampleRate();
+
+    // Setup CPU logging of the audio callback
+    cpuLoadMeter.Init(sample_rate, blockSize);
 
     // Set the number of samples to use for the crossfade based on the hardware sample rate
     muteOffTransitionTimeInSamples = hardware.GetNumberOfSamplesForTime(muteOffTransitionTimeInSeconds);
@@ -637,9 +642,6 @@ int main(void) {
 
     // Setup Debug Logging
     // hardware.seed.StartLog();
-
-    // Setup CPU logging of the audio callback
-    cpuLoadMeter.Init(hardware.AudioSampleRate(), hardware.AudioBlockSize());
 
     while (1) {
         // Handle Clock Time


### PR DESCRIPTION
Fixes #58 

I think with NAM and some of the newer modules, this is a valuable tool. It is very lightweight (https://electro-smith.github.io/libDaisy/_cpu_load_meter_8h_source.html) so I have no hesitations about just leaving it in like this instead of using `#ifdef` to disable it or something

@GuitarML I will let you do your own poking around if you are interested but the NAM module is using ~70% on my unit. The Amp module is interesting too because you can turn the IR and/or model on or off interdependently as well.