### PR TITLE
Adjust GCC version for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
         uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:
-          release: "latest"
+          release: "10.3-2021.10"
       - name: Build Libraries
         working-directory: Software/GuitarPedal/
         run: ./ci/build_libs.sh


### PR DESCRIPTION
Might be a good idea to pin this to something with more documented support with the daisy seed SDK and platform..

Some interesting release notes here: https://github.com/electro-smith/DaisyToolchain/releases

So this is probably a good idea...