### PR TITLE
CloudSeed alternate button to mute input signal on wet

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/cloudseed_module.h
+++ b/Software/GuitarPedal/Effect-Modules/cloudseed_module.h
@@ -3,6 +3,7 @@
 #define CLOUDSEED_MODULE_H
 
 #include "base_effect_module.h"
+#include "linear_change.h"
 #include "daisysp.h"
 #include <stdint.h>
 
@@ -28,22 +29,36 @@ class CloudSeedModule : public BaseEffectModule {
     void Init(float sample_rate) override;
     void ParameterChanged(int parameter_id) override;
     void changePreset();
-    void CalculateMix();
     void ProcessMono(float in) override;
     void ProcessStereo(float inL, float inR) override;
     float GetBrightnessForLED(int led_id) const override;
+    bool AlternateFootswitchForTempo() const override { return false; }
+    void AlternateFootswitchPressed() override;
 
   private:
+    struct Mix {
+        float wet;
+        float dry;
+    };
+
+    void CalculateMix();
+    Mix CalculateMix(float mixValue);
+
     CloudSeed::ReverbController *reverb = 0;
 
     float m_gainMin;
     float m_gainMax;
     int throttle_counter = 0;
 
-    float wetMix;
-    float dryMix;
+    Mix currentMix;
 
     float m_cachedEffectMagnitudeValue;
+
+    bool inputMuteForWet = false;
+
+    // Gradual transition of dry mix
+    static constexpr int linearChangeDryLevelSteps = 25000; // Number of steps for gradual change
+    LinearChange linearChangeDryLevel;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Effect-Modules/linear_change.h
+++ b/Software/GuitarPedal/Effect-Modules/linear_change.h
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef LINEAR_CHANGE_H
+#define LINEAR_CHANGE_H
+
+namespace bkshepherd {
+
+class LinearChange {
+  public:
+    LinearChange() : active(false) {}
+    
+    void activate(float startValue, float endValue, int steps) {
+        start = startValue;
+        end = endValue;
+        totalSteps = steps;
+        currentStep = 0;
+        active = true;
+    }
+    float getNextValue() {
+        if (!active) {
+            return end;
+        }
+        if (currentStep >= totalSteps) {
+            active = false;
+            return end;
+        }
+        float value = start + ((end - start) * ((float)currentStep / (float)totalSteps));
+        currentStep++;
+        return value;
+    }
+
+    bool isActive() const { return active; }
+    void deactivate() { active = false; }
+
+  private:
+    float start;
+    float end;
+    int currentStep;
+    int totalSteps;
+    bool active;
+};
+
+} // namespace bkshepherd
+
+#endif // LINEAR_CHANGE_H

--- a/Software/GuitarPedal/guitar_pedal_storage.h
+++ b/Software/GuitarPedal/guitar_pedal_storage.h
@@ -3,7 +3,7 @@
 #define GUITAR_PEDAL_STORAGE_H
 
 // Persistent Storage Settings
-#define SETTINGS_FILE_FORMAT_VERSION 6
+#define SETTINGS_FILE_FORMAT_VERSION 7
 
 // Arbitrarily limiting this to 4KB of stored presets since this sits in DTCMRAM which is limited to 128KB.
 // TODO: In the future it would be better if this worked with the QSPI directly instead of using


### PR DESCRIPTION
Allow using the alternate button to mute the input signal for the wet mix while keeping the dry input in the mix.
dry input level is configurable when signal is muted for wet.
mix knob is remapped to be alternate dry input volume when alternate mode is on.

To be used with long cloudseed decays.