### PR TITLE
Add check for encoder support.

### DIFF
--- a/Software/GuitarPedal/Hardware-Modules/base_hardware_module.cpp
+++ b/Software/GuitarPedal/Hardware-Modules/base_hardware_module.cpp
@@ -4,8 +4,8 @@ using namespace daisy;
 using namespace bkshepherd;
 
 BaseHardwareModule::BaseHardwareModule()
-    : m_supportsStereo(false), m_supportsMidi(false), m_supportsDisplay(false), m_supportsTrueBypass(false),
-      m_switchMetaDataParamCount(0) {
+    : m_supportsStereo(false), m_supportsMidi(false), m_supportsDisplay(false), m_supportsEncoder(false),
+      m_supportsTrueBypass(false), m_switchMetaDataParamCount(0) {
     m_switchMetaData = nullptr;
 }
 
@@ -157,6 +157,8 @@ bool BaseHardwareModule::SupportsMidi() { return m_supportsMidi; }
 
 bool BaseHardwareModule::SupportsDisplay() { return m_supportsDisplay; }
 
+bool BaseHardwareModule::SupportsEncoder() { return m_supportsEncoder; }
+
 bool BaseHardwareModule::SupportsTrueBypass() { return m_supportsTrueBypass; }
 
 void BaseHardwareModule::InitKnobs(int count, Pin pins[]) {
@@ -191,6 +193,10 @@ void BaseHardwareModule::InitEncoders(int count, Pin pins[][3]) {
         Encoder myEncoder;
         myEncoder.Init(pins[i][0], pins[i][1], pins[i][2]);
         encoders.push_back(myEncoder);
+    }
+
+    if (count > 0) {
+        m_supportsEncoder = true;
     }
 }
 

--- a/Software/GuitarPedal/Hardware-Modules/base_hardware_module.h
+++ b/Software/GuitarPedal/Hardware-Modules/base_hardware_module.h
@@ -182,6 +182,9 @@ class BaseHardwareModule {
     /** Checks to see if device hardware supports the Display*/
     bool SupportsDisplay();
 
+    /** Checks to see if device hardware supports an Encoder*/
+    bool SupportsEncoder();
+
     /** Checks to see if device hardware supports True Bypass*/
     bool SupportsTrueBypass();
 
@@ -201,6 +204,7 @@ class BaseHardwareModule {
     bool m_supportsStereo;
     bool m_supportsMidi;
     bool m_supportsDisplay;
+    bool m_supportsEncoder;
     bool m_supportsTrueBypass;
     bool m_audioBypass;
     bool m_audioMute;

--- a/Software/GuitarPedal/UI/guitar_pedal_ui.cpp
+++ b/Software/GuitarPedal/UI/guitar_pedal_ui.cpp
@@ -122,8 +122,10 @@ int GuitarPedalUI::GetActiveEffectIDFromSettingsMenu() { return m_availableEffec
 
 void GuitarPedalUI::InitUi() {
     UI::SpecialControlIds specialControlIds;
-    specialControlIds.okBttnId = 0;      // Encoder button is our okay button
-    specialControlIds.menuEncoderId = 0; // Encoder is used as the main menu navigation encoder
+    if (hardware.SupportsEncoder()) {
+        specialControlIds.okBttnId = 0;      // Encoder button is our okay button
+        specialControlIds.menuEncoderId = 0; // Encoder is used as the main menu navigation encoder
+    }
 
     // This is the canvas for the OLED display.
     UiCanvasDescriptor oledDisplayDescriptor;
@@ -344,7 +346,7 @@ void GuitarPedalUI::InitGlobalSettingsUIPages() {
 }
 
 void GuitarPedalUI::GenerateUIEvents() {
-    if (!hardware.SupportsDisplay()) {
+    if (!hardware.SupportsDisplay() || !hardware.SupportsEncoder()) {
         return;
     }
 

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -690,17 +690,19 @@ int main(void) {
         }
 
         // If alt footswitch held AND encoder turned, iterate to next/previous effect, also throttle the changes
-        const int encoderIncrement = hardware.encoders[0].Increment();
-        if (has_alternate_footswitch &&
+        if (hardware.SupportsEncoder() && has_alternate_footswitch &&
             hardware.switches[hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)].Pressed() &&
-            encoderIncrement != 0 && System::GetNow() - last_effect_change_time >= 10) {
-            int desiredIndex = activeEffectID - encoderIncrement;
-            if (desiredIndex > availableEffectsCount - 1) {
-                desiredIndex = 0;
-            } else if (desiredIndex < 0) {
-                desiredIndex = availableEffectsCount - 1;
+            System::GetNow() - last_effect_change_time >= 10) {
+            const int encoderIncrement = hardware.encoders[0].Increment();
+            if (encoderIncrement != 0) {
+                int desiredIndex = activeEffectID - encoderIncrement;
+                if (desiredIndex > availableEffectsCount - 1) {
+                    desiredIndex = 0;
+                } else if (desiredIndex < 0) {
+                    desiredIndex = availableEffectsCount - 1;
+                }
+                SetActiveEffect(desiredIndex);
             }
-            SetActiveEffect(desiredIndex);
         }
 
         if (hardware.SupportsDisplay()) {


### PR DESCRIPTION
@GuitarML @xconverge don't you guys have issues with the Funbox? 

I have a similar pedal variation (no encoder, no display). When I press the alternate footswith I often get the active effect changing to the next one on the list. This happens because of this code section:
`// If alt footswitch held AND encoder turned, iterate to next/previous effect, also throttle the changes
 const int encoderIncrement = hardware.encoders[0].Increment();`

Because the `encoders`vector is empty I get random non-zero values for `Increment()`.
This PR defines explicitely if the pedal variation has an encoder or not.