### PR TITLE
Add ability to use knobs for more parameters in delay module

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/base_effect_module.h
+++ b/Software/GuitarPedal/Effect-Modules/base_effect_module.h
@@ -160,7 +160,7 @@ class BaseEffectModule {
      \param knob_id Id of the Knob to retrieve.
      \return the Parameter ID mapped to the specified knob, or -1 if no Parameter is Mapped to that Knob
     */
-    int GetMappedParameterIDForKnob(int knob_id) const;
+    virtual int GetMappedParameterIDForKnob(int knob_id) const;
 
     /** Gets the Parameter ID of the Effect Parameter mapped to this Midi CC ID.
      \param midiCC_id Id of the MidiCC to retrieve.

--- a/Software/GuitarPedal/Effect-Modules/delay_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/delay_module.cpp
@@ -550,8 +550,7 @@ void DelayModule::DrawUI(OneBitGraphicsDisplay &display, int currentIndex, int n
 
     // If shift mode is active, display a "SHIFT" indicator on the UI
     if (m_shiftModeActive) {
-        // Draw "SHIFT" text in the top right corner
-        display.SetCursor(boundsToDrawIn.GetRight() - 40, boundsToDrawIn.GetTop() + 2);
+        display.SetCursor(boundsToDrawIn.GetRight() - 40, 2);
         display.WriteString("SHIFT", Font_6x8, true);
     }
 }

--- a/Software/GuitarPedal/Effect-Modules/delay_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/delay_module.cpp
@@ -291,7 +291,7 @@ void DelayModule::ProcessModulation() {
 
         if (waveForm == 5) {
             // Tape flutter mode with dynamic min
-            const float M     = wowDepth + 0.2f * flutterDepth; // Max amplitude of tape modulation.
+            const float M = wowDepth + 0.2f * flutterDepth; // Max amplitude of tape modulation.
             const float depth = 500.0f;
 
             float baseMin = D_min + M * mod_amount * depth;
@@ -300,7 +300,7 @@ void DelayModule::ProcessModulation() {
             float base = baseMin + (baseMax - baseMin) * timeParam;
 
             delayTarget = base + mod * mod_amount * depth;
-        } else {        
+        } else {
             delayTarget = m_delaySamplesMin + (m_delaySamplesMax - m_delaySamplesMin) * timeParam + mod * mod_amount * 500;
         }
         if (delayTarget < D_min) {
@@ -310,7 +310,7 @@ void DelayModule::ProcessModulation() {
             delayTarget = MAX_DELAY_NORM - 2;
         }
 
-        delayLeft.delayTarget  = delayTarget;
+        delayLeft.delayTarget = delayTarget;
         delayRight.delayTarget = delayTarget;
     } else if (modParam == 2) {
         float mod_level = mod * mod_amount + (1.0 - mod_amount);
@@ -510,4 +510,48 @@ float DelayModule::GetBrightnessForLED(int led_id) const {
     }
 
     return value;
+}
+
+int DelayModule::GetMappedParameterIDForKnob(int knob_id) const {
+    // If shift mode is active, remap knobs 0-5 to alternate parameters
+    if (m_shiftModeActive) {
+        switch (knob_id) {
+        case 0:
+            return MOD_AMT; // Knob 0 -> Mod Amount
+        case 1:
+            return MOD_RATE; // Knob 1 -> Mod Rate
+        case 2:
+            return MOD_WAVE; // Knob 2 -> Mod Waveform
+        case 3:
+            return MOD_PARAM; // Knob 3 -> Mod Parameter
+        case 4:
+            return SYNC_MOD_F; // Knob 4 -> Sync Mod Frequency (bool)
+        case 5:
+            return D_SPREAD; // Knob 5 -> Delay Spread
+        default:
+            return -1;
+        }
+    }
+
+    // Normal mode: use default mapping from metadata
+    return BaseEffectModule::GetMappedParameterIDForKnob(knob_id);
+}
+
+void DelayModule::AlternateFootswitchHeldFor1Second() {
+    // If held for 1 second, toggle shift mode (uses same knobs as mod controls for
+    // alternate parameter control)
+    m_shiftModeActive = !m_shiftModeActive;
+}
+
+void DelayModule::DrawUI(OneBitGraphicsDisplay &display, int currentIndex, int numItemsTotal, Rectangle boundsToDrawIn,
+                         bool isEditing) {
+    // Draw the base UI
+    BaseEffectModule::DrawUI(display, currentIndex, numItemsTotal, boundsToDrawIn, isEditing);
+
+    // If shift mode is active, display a "SHIFT" indicator on the UI
+    if (m_shiftModeActive) {
+        // Draw "SHIFT" text in the top right corner
+        display.SetCursor(boundsToDrawIn.GetRight() - 40, boundsToDrawIn.GetTop() + 2);
+        display.WriteString("SHIFT", Font_6x8, true);
+    }
 }

--- a/Software/GuitarPedal/Effect-Modules/delay_module.h
+++ b/Software/GuitarPedal/Effect-Modules/delay_module.h
@@ -185,6 +185,7 @@ class DelayModule : public BaseEffectModule {
 
     // Shift layer for alternate knob mapping
     bool m_shiftModeActive = false;
+        bool m_shiftModeToggled = false;  // Gate to prevent multiple toggles during single hold
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Effect-Modules/delay_module.h
+++ b/Software/GuitarPedal/Effect-Modules/delay_module.h
@@ -144,6 +144,10 @@ class DelayModule : public BaseEffectModule {
     void ProcessStereo(float inL, float inR) override;
     void SetTempo(uint32_t bpm) override;
     float GetBrightnessForLED(int led_id) const override;
+    int GetMappedParameterIDForKnob(int knob_id) const override;
+    void AlternateFootswitchHeldFor1Second() override;
+    void DrawUI(OneBitGraphicsDisplay &display, int currentIndex, int numItemsTotal, Rectangle boundsToDrawIn,
+                bool isEditing) override;
 
   private:
     float m_delaylpFreqMin;
@@ -178,6 +182,9 @@ class DelayModule : public BaseEffectModule {
     // Oscillator for blinking tempo LED
     Oscillator led_osc;
     float m_LEDValue;
+
+    // Shift layer for alternate knob mapping
+    bool m_shiftModeActive = false;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -101,6 +101,7 @@ int switchEnabledIdleTimeInSamples;
 bool *switchEnabledCache = nullptr;
 bool *switchDoubleEnabledCache = nullptr;
 int *switchEnabledSamplesTilIdle = nullptr;
+bool alternateHeldFor1SecondTriggered = false;
 
 // Tempo
 bool needToChangeTempo = false;
@@ -285,12 +286,17 @@ static void AudioCallback(AudioHandle::InputBuffer in, AudioHandle::OutputBuffer
         }
 
         bool switchReleased = hardware.switches[i].FallingEdge();
+        if (switchReleased && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
+            alternateHeldFor1SecondTriggered = false;
+        }
         if (effectOn && switchReleased && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
             activeEffect->AlternateFootswitchReleased();
         }
 
         bool switchHeld = hardware.switches[i].TimeHeldMs() >= 1000.f;
-        if (effectOn && switchHeld && i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
+        if (effectOn && switchHeld && !alternateHeldFor1SecondTriggered &&
+            i == hardware.GetPreferredSwitchIDForSpecialFunctionType(SpecialFunctionType::Alternate)) {
+            alternateHeldFor1SecondTriggered = true;
             activeEffect->AlternateFootswitchHeldFor1Second();
         }
 


### PR DESCRIPTION
Hold the footswitch for 1 second and the 6 knobs are usable for the 2nd set of 6 parameters for the delay effect. Hold the footswitch for 1 second to return.

This will allow me to use/setup the new tape delay (https://github.com/bkshepherd/DaisySeedProjects/pull/80) from @chattob  exactly how I want without MIDI