### PR TITLE
Fix bugs found in code review across pitch shifter, modules, and core

### DIFF
--- a/Software/GuitarPedal/Effect-Modules/autopan_module.h
+++ b/Software/GuitarPedal/Effect-Modules/autopan_module.h
@@ -36,7 +36,7 @@ class AutoPanModule : public BaseEffectModule {
                 bool isEditing) override;
 
   private:
-    float m_pan; // 0 to 1 value 0 is full left, 1 is full right.
+    float m_pan = 0.5f; // 0 to 1 value 0 is full left, 1 is full right.
     Oscillator m_freqOsc;
     float m_freqOscFreqMin;
     float m_freqOscFreqMax;

--- a/Software/GuitarPedal/Effect-Modules/base_effect_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/base_effect_module.cpp
@@ -149,7 +149,7 @@ uint32_t BaseEffectModule::GetParameterRaw(int parameter_id) const {
 }
 
 float BaseEffectModule::GetParameterAsFloat(int parameter_id) const {
-    if (parameter_id >= 0 || parameter_id < m_paramCount) {
+    if (m_params != nullptr && parameter_id >= 0 && parameter_id < m_paramCount) {
         float ret;
         uint32_t tmp = m_params[parameter_id];
         std::memcpy(&ret, &tmp, sizeof(float));
@@ -326,14 +326,17 @@ void BaseEffectModule::SetParameterAsMagnitude(int parameter_id, float value) {
             return;
         }
 
-        // Map values 0..1 to the bins equally
-        int mappedBin = (int)(value * GetParameterBinCount(parameter_id) + 1);
+        // Map values 0..1 to the bins equally. A magnitude of exactly 1.0
+        // (e.g. MIDI CC 127) would otherwise compute binCount + 1, which
+        // SetParameterAsBinnedValue rejects, so clamp to the last bin.
+        int binCount = GetParameterBinCount(parameter_id);
+        int mappedBin = std::min((int)(value * binCount + 1), binCount);
         SetParameterAsBinnedValue(parameter_id, mappedBin);
     }
 }
 
 void BaseEffectModule::SetParameterAsFloat(int parameter_id, float value) {
-    if (parameter_id >= 0 || parameter_id < m_paramCount) {
+    if (m_params != nullptr && parameter_id >= 0 && parameter_id < m_paramCount) {
         uint32_t tmp;
         std::memcpy(&tmp, &value, sizeof(float));
 

--- a/Software/GuitarPedal/Effect-Modules/crusher_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/crusher_module.cpp
@@ -34,7 +34,7 @@ static const auto s_metaData = [] {
         name : "Bits",
         valueType : ParameterValueType::Binned,
         valueBinCount : 32,
-        defaultValue : {.uint_value = 32},
+        defaultValue : {.uint_value = 31}, // raw values are 0-based: 31 = bin 32 (full bit depth)
         knobMapping : 1,
         midiCCMapping : 15
     }; // Bit depth for quantization (lower bits = more digital distortion).
@@ -120,6 +120,12 @@ void CrusherModule::Init(float sample_rate) {
 
     m_bitcrusherL.Init(sample_rate);
     m_bitcrusherR.Init(sample_rate);
+
+    // Initialize the pitch detector here rather than lazily in the audio
+    // path: its setup allocates, which is not safe in the audio callback
+    if (!m_pitchDetector.IsInitialized()) {
+        m_pitchDetector.Init(m_rateMax);
+    }
 }
 
 void CrusherModule::AlternateFootswitchPressed() {
@@ -204,9 +210,9 @@ float CrusherModule::GetSrrRate(float detectorInput) {
     }
 
     if(!m_pitchDetector.IsInitialized()) {
-        // Defer the heavy q pitch-detector allocation until the feature is
-        // actually enabled.
-        m_pitchDetector.Init(m_rateMax);
+        // The detector is initialized in Init(); if that somehow didn't
+        // happen, fall back to the manual rate rather than allocating here
+        return manualRate;
     }
 
     const float rateControl = GetParameterAsFloat(RATE);

--- a/Software/GuitarPedal/Effect-Modules/delay_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/delay_module.cpp
@@ -187,6 +187,7 @@ void DelayModule::Init(float sample_rate) {
     delayLeft.del = &delayLineLeft;
     delayLeft.delreverse = &delayLineRevLeft;
     delayLeft.delayTarget = 24000; // in samples
+    delayLeft.currentDelay = 24000;
     delayLeft.feedback = 0.0;
     delayLeft.active = true; // Default to no delay
     delayLeft.toneOctLP.Init(sample_rate);
@@ -197,6 +198,7 @@ void DelayModule::Init(float sample_rate) {
     delayRight.del = &delayLineRight;
     delayRight.delreverse = &delayLineRevRight;
     delayRight.delayTarget = 24000; // in samples
+    delayRight.currentDelay = 24000;
     delayRight.feedback = 0.0;
     delayRight.active = true; // Default to no
     delayRight.toneOctLP.Init(sample_rate);
@@ -205,6 +207,7 @@ void DelayModule::Init(float sample_rate) {
     delayLineSpread.Init();
     delaySpread.del = &delayLineSpread;
     delaySpread.delayTarget = 1500; // in samples
+    delaySpread.currentDelay = 1500;
     delaySpread.active = true;
 
     effect_samplerate = sample_rate;
@@ -320,9 +323,9 @@ void DelayModule::ProcessModulation() {
         delayRight.level_reverse = mod_level;
 
     } else if (modParam == 3) {
-        _level = mod * mod_amount + (1.0 - mod_amount);
-
-    } else if (modParam == 4) {
+        // "DelayPan": pan the delay by modulating the levels in opposite
+        // directions per side (this branch previously required modParam == 4,
+        // which the 4-bin mod parameter could never produce)
         float mod_level = mod * mod_amount + (1.0 - mod_amount);
         delayLeft.level = mod_level;
         delayRight.level = 1.0 - mod_level;

--- a/Software/GuitarPedal/Effect-Modules/distortion_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/distortion_module.cpp
@@ -172,31 +172,6 @@ float dynamicPreFilterCutoff(float inputEnergy) {
     return preFilterCutoffBase + (preFilterCutoffMax - preFilterCutoffBase) * std::tanh(inputEnergy);
 }
 
-// Helper functions for oversampling
-std::vector<float> upsample(const std::vector<float> &input, int factor, float sample_rate) {
-    std::vector<float> output(input.size() * factor, 0.0f);
-
-    for (size_t i = 0; i < input.size(); ++i) {
-        // Insert input samples, leaving zeros in between
-        output[i * factor] = input[i];
-    }
-
-    // Apply the low-pass filter to smooth interpolated samples
-    for (size_t i = 1; i < output.size(); ++i) {
-        output[i] = upsamplingLowpassFilter(output[i]);
-    }
-
-    return output;
-}
-
-std::vector<float> downsample(const std::vector<float> &input, int factor) {
-    std::vector<float> output(input.size() / factor);
-    for (size_t i = 0; i < output.size(); ++i) {
-        output[i] = input[i * factor]; // Take every nth sample
-    }
-    return output;
-}
-
 void processDistortion(float &sample,           // Sample to process
                        const float &gain,       // Gain
                        const int &clippingType, // Clipping type
@@ -265,21 +240,27 @@ void DistortionModule::ProcessMono(float in) {
     distorted = distorted * 0.5f;
 
     if (m_oversampling) {
-        // Prepare signal for oversampling
-        std::vector<float> monoInput = {distorted};
-        std::vector<float> oversampledInput = upsample(monoInput, oversamplingFactor, GetSampleRate());
+        // Zero-stuff to the oversampled rate, smooth the inserted zeros with
+        // the upsampling low-pass, distort and post-filter each oversampled
+        // sample, then decimate by taking the first sample. Uses a fixed
+        // stack buffer; this runs per audio sample so it must not allocate.
+        float oversampled[oversamplingFactor];
+        oversampled[0] = distorted;
+        for (int i = 1; i < oversamplingFactor; ++i) {
+            oversampled[i] = upsamplingLowpassFilter(0.0f);
+        }
 
         // Apply gain and distortion processing
-        for (float &sample : oversampledInput) {
+        for (float &sample : oversampled) {
             processDistortion(sample, gain, clippingType, intensity);
 
             // Post-filter: Low-pass to smooth out harsh high frequencies
             sample = postFilter(sample);
         }
 
-        // Downsample back to original sample rate
-        const std::vector<float> downsampledOutput = downsample(oversampledInput, oversamplingFactor);
-        distorted = downsampledOutput[0];
+        // Downsample back to original sample rate (decimate: every
+        // oversamplingFactor-th sample, i.e. index 0 of this frame)
+        distorted = oversampled[0];
 
         // Apply gain compensation for oversampling
         distorted *= oversamplingFactor;

--- a/Software/GuitarPedal/Effect-Modules/granulardelay_module.h
+++ b/Software/GuitarPedal/Effect-Modules/granulardelay_module.h
@@ -51,7 +51,7 @@ class GranularDelayModule : public BaseEffectModule {
     float m_grain_size;
     float m_width;
 
-    float m_current_grainsize;
+    float m_current_grainsize = 0.0f;
 
     int first_count;
     bool m_loop_recorded;

--- a/Software/GuitarPedal/Effect-Modules/metro_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/metro_module.cpp
@@ -177,7 +177,11 @@ void MetroModule::ProcessStereo(float inL, float inR) {
     m_audioRight = sig * level + inR * (1.0f - level);
 }
 
-void MetroModule::SetTempo(uint32_t bpm) { m_bpm = std::clamp(bpm, minTempo, maxTempo); }
+void MetroModule::SetTempo(uint32_t bpm) {
+    m_bpm = std::clamp(bpm, minTempo, maxTempo);
+    // Keep the stored/displayed TEMPO parameter in sync with tap tempo
+    SetParameterAsFloat(TEMPO, m_bpm);
+}
 
 float MetroModule::GetBrightnessForLED(int led_id) const {
     float value = BaseEffectModule::GetBrightnessForLED(led_id);

--- a/Software/GuitarPedal/Effect-Modules/midi_keys_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/midi_keys_module.cpp
@@ -93,7 +93,7 @@ void MidiKeysModule::ProcessStereo(float inL, float inR) {
     float sum = 0.f;
     sum = voice_handler.Process() * 0.4f * GetParameterAsFloat(LEVEL); // was 0.5f, needs more volume reduction
     m_audioLeft = sum + through_audioL;
-    m_audioRight = m_audioLeft + through_audioR;
+    m_audioRight = sum + through_audioR;
 }
 
 float MidiKeysModule::GetBrightnessForLED(int led_id) const {

--- a/Software/GuitarPedal/Effect-Modules/multi_delay_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/multi_delay_module.cpp
@@ -3,6 +3,7 @@
 #include "Delays/delayline_reverse.h"
 #include "Delays/delayline_revoct.h"
 #include "daisysp.h"
+#include <algorithm>
 #include <array>
 
 using namespace bkshepherd;
@@ -90,8 +91,8 @@ static const auto s_metaData = [] {
         valueBinCount : 2,
         valueBinNames : s_typeBinNames,
         defaultValue : {.uint_value = 0},
-        knobMapping : 1,
-        midiCCMapping : 20
+        knobMapping : 4,
+        midiCCMapping : 32
     };
 
     params[MultiDelayModule::SHIFT_TAP_1] = {
@@ -249,15 +250,17 @@ void MultiDelayModule::ParameterChanged(int parameter_id) {
             SetTargetTapDelayTime(3, delays[1].delayTarget, 4.0f);
         }
     } else if (parameter_id > 4 && parameter_id < 9 && m_isInitialized == true) {
-        ps_taps[parameter_id - 5].SetTransposition(m_pitchShiftMin +
-                                                   (m_pitchShiftMax - m_pitchShiftMin) * GetParameterAsFloat(parameter_id));
-    } else if (parameter_id > 8 && parameter_id < 11) {
+        // The stored parameter value is already in semitones (-12..12)
+        ps_taps[parameter_id - 5].SetTransposition(GetParameterAsFloat(parameter_id));
+    } else if (parameter_id > 8 && parameter_id < 13) {
         m_tapTargetDelay[parameter_id - 9] = 48.0f * GetParameterAsFloat(parameter_id);
     }
 }
 
 void MultiDelayModule::SetTargetTapDelayTime(uint8_t index, float value, float multiplier) {
-    m_tapTargetDelay[index] = value * multiplier;
+    // In follower mode the 2x/4x multiples of a long delay can exceed the
+    // delay line; clamp so the tap doesn't alias to a wrapped position
+    m_tapTargetDelay[index] = std::min(value * multiplier, static_cast<float>(MAX_DELAY_TAP - 1));
 }
 
 void PreProcessTaps(float *current, float target) { fonepole(*current, target, .0002f); }

--- a/Software/GuitarPedal/Effect-Modules/noise_gate_module.h
+++ b/Software/GuitarPedal/Effect-Modules/noise_gate_module.h
@@ -41,11 +41,11 @@ class NoiseGateModule : public BaseEffectModule {
     // derivative cutoff freq: used when beta is > 0
     one_euro_filter<float, float> m_smoothingFilter{48000, 0.5f, 0.05f, 1.0f};
 
-    float m_holdTimer; // Timer tracking hold duration
-    bool m_gateOpen;   // Is the gate currently open?
-    float m_prevTimeSeconds;
+    float m_holdTimer = 0.0f; // Timer tracking hold duration
+    bool m_gateOpen = false;   // Is the gate currently open?
+    float m_prevTimeSeconds = 0.0f;
 
-    float m_currentGain;
+    float m_currentGain = 0.0f;
 };
 } // namespace bkshepherd
 #endif

--- a/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.cpp
@@ -248,19 +248,15 @@ float PitchShifterModule::ProcessMomentaryMode(float in) {
         // transition time
         m_sampleCounter = 0;
 
+        // Process the pitch shift for completely active to the target by default
+        float semitone = m_semitoneTarget;
         if (!m_alternateFootswitchPressed) {
-            // Completely inactive: output the dry signal. Running the shifter at
-            // 0 semitones instead would leave the two delay taps frozen at an
-            // arbitrary phase (the LFOs stop), comb filtering the signal at a
-            // level that varies with every release. Keep feeding the delay
-            // lines so the buffer is warm when the next ramp starts.
-            SetTranspose(0.0f);
-            pitchShifter.Process(in);
-            return in;
+            // Process the pitch shift for completely inactive (0)
+            semitone = 0.0f;
         }
 
         // Process the pitch shift for completely active to the target
-        SetTranspose(m_semitoneTarget);
+        SetTranspose(semitone);
         float shifted = pitchShifter.Process(in);
         float out = pitchCrossfade.Process(in, shifted);
         return out;

--- a/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/pitch_shifter_module.cpp
@@ -12,10 +12,9 @@ static const char *s_semitoneBinNames[8] = {"1", "2", "3", "4", "5", "6", "7", "
 static const char *s_directionBinNames[2] = {"DOWN", "UP"};
 static const char *s_modeBinNames[2] = {"LATCH", "MOMENT"};
 
-// How many samples to delay to based on the "Delay" knob and parameter
-// when the time knob is set to max, this is used for the ramp up/down
-// transition when in momentary mode. Has no effect on latching mode
-const uint32_t k_maxSamplesMaxTime = 48000 * 2;
+// Maximum ramp up/down transition time in seconds when the shift/return
+// knob is set to max, used in momentary mode. Has no effect on latching mode
+const float k_maxTransitionTimeSeconds = 2.0f;
 
 // Larger delay size is higher fidelity/quality for a farther transpose, at
 // the cost of additional latency (like...a lot of latency)
@@ -160,8 +159,9 @@ void PitchShifterModule::Init(float sample_rate) {
 
     SetTranspose(m_semitoneTarget);
 
-    m_samplesToDelayShift = static_cast<uint32_t>(static_cast<float>(k_maxSamplesMaxTime) * GetParameterAsFloat(SHIFT));
-    m_samplesToDelayReturn = static_cast<uint32_t>(static_cast<float>(k_maxSamplesMaxTime) * GetParameterAsFloat(RETURN));
+    const float maxTransitionSamples = sample_rate * k_maxTransitionTimeSeconds;
+    m_samplesToDelayShift = static_cast<uint32_t>(maxTransitionSamples * GetParameterAsFloat(SHIFT));
+    m_samplesToDelayReturn = static_cast<uint32_t>(maxTransitionSamples * GetParameterAsFloat(RETURN));
 }
 
 void PitchShifterModule::ParameterChanged(int parameter_id) {
@@ -178,9 +178,9 @@ void PitchShifterModule::ParameterChanged(int parameter_id) {
             pitchShifter.SetDelSize(k_defaultSamplesDelayPitchShifter);
         }
     } else if (parameter_id == SHIFT) {
-        m_samplesToDelayShift = static_cast<uint32_t>(static_cast<float>(k_maxSamplesMaxTime) * GetParameterAsFloat(SHIFT));
+        m_samplesToDelayShift = static_cast<uint32_t>(GetSampleRate() * k_maxTransitionTimeSeconds * GetParameterAsFloat(SHIFT));
     } else if (parameter_id == RETURN) {
-        m_samplesToDelayReturn = static_cast<uint32_t>(static_cast<float>(k_maxSamplesMaxTime) * GetParameterAsFloat(RETURN));
+        m_samplesToDelayReturn = static_cast<uint32_t>(GetSampleRate() * k_maxTransitionTimeSeconds * GetParameterAsFloat(RETURN));
     }
 
     // Parameters changed, reset the transposition target just in case (mostly
@@ -248,15 +248,19 @@ float PitchShifterModule::ProcessMomentaryMode(float in) {
         // transition time
         m_sampleCounter = 0;
 
-        // Process the pitch shift for completely active to the target by default
-        float semitone = m_semitoneTarget;
         if (!m_alternateFootswitchPressed) {
-            // Process the pitch shift for completely inactive (0)
-            semitone = 0.0f;
+            // Completely inactive: output the dry signal. Running the shifter at
+            // 0 semitones instead would leave the two delay taps frozen at an
+            // arbitrary phase (the LFOs stop), comb filtering the signal at a
+            // level that varies with every release. Keep feeding the delay
+            // lines so the buffer is warm when the next ramp starts.
+            SetTranspose(0.0f);
+            pitchShifter.Process(in);
+            return in;
         }
 
         // Process the pitch shift for completely active to the target
-        SetTranspose(semitone);
+        SetTranspose(m_semitoneTarget);
         float shifted = pitchShifter.Process(in);
         float out = pitchCrossfade.Process(in, shifted);
         return out;

--- a/Software/GuitarPedal/Effect-Modules/pluckecho_module.h
+++ b/Software/GuitarPedal/Effect-Modules/pluckecho_module.h
@@ -44,7 +44,7 @@ class PluckEchoModule : public BaseEffectModule {
     // ReverbSc                                  verb;
 
     // Persistent filtered Value for smooth delay time changes.
-    float smooth_time;
+    float smooth_time = 0.0f;
 
     float m_freqMin;
     float m_freqMax;

--- a/Software/GuitarPedal/Effect-Modules/polyoctave_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/polyoctave_module.cpp
@@ -95,8 +95,8 @@ void PolyOctaveModule::ProcessMono(float in) {
     buff[bin_counter] = in; // making a workaround for only processing sample by sample instead of block, will add 6 samples of latency
 
     float dryLevel = GetParameterAsFloat(DRY);
-    float down1Level = GetParameterAsFloat(TWO_OCT_DOWN);
-    float down2Level = GetParameterAsFloat(ONE_OCT_DOWN);
+    float down1Level = GetParameterAsFloat(ONE_OCT_DOWN);
+    float down2Level = GetParameterAsFloat(TWO_OCT_DOWN);
     float up1Level = GetParameterAsFloat(ONE_OCT_UP);
 
     // for (size_t i = 0; i <= (size - resample_factor); i += resample_factor)  // Every 6 samples until block size

--- a/Software/GuitarPedal/Effect-Modules/reverb_delay_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/reverb_delay_module.cpp
@@ -258,6 +258,7 @@ void ReverbDelayModule::Init(float sample_rate) {
     delayLeft.del = &delayLineLeft;
     delayLeft.delreverse = &delayLineRevLeft;
     delayLeft.delayTarget = 24000; // in samples
+    delayLeft.currentDelay = 24000;
     delayLeft.feedback = 0.0;
     delayLeft.active = true; // Default to no delay
     delayLeft.toneOctLP.Init(sample_rate);
@@ -268,6 +269,7 @@ void ReverbDelayModule::Init(float sample_rate) {
     delayRight.del = &delayLineRight;
     delayRight.delreverse = &delayLineRevRight;
     delayRight.delayTarget = 24000; // in samples
+    delayRight.currentDelay = 24000;
     delayRight.feedback = 0.0;
     delayRight.active = true; // Default to no
     delayRight.toneOctLP.Init(sample_rate);
@@ -276,6 +278,7 @@ void ReverbDelayModule::Init(float sample_rate) {
     delayLineSpread.Init();
     delaySpread.del = &delayLineSpread;
     delaySpread.delayTarget = 1500; // in samples
+    delaySpread.currentDelay = 1500;
     delaySpread.active = true;
 
     m_reverbStereo.Init(sample_rate);
@@ -392,7 +395,7 @@ void ReverbDelayModule::ProcessMono(float in) {
     delayLeft.dual_delay = GetParameterAsBool(DUAL_DELAY);
     delayRight.dual_delay = GetParameterAsBool(DUAL_DELAY);
 
-    if (GetParameterAsFloat(DUAL_DELAY)) { // If dual delay is turned on, spread controls the L/R panning of the two delays
+    if (GetParameterAsBool(DUAL_DELAY)) { // If dual delay is turned on, spread controls the L/R panning of the two delays
         delayLeft.level = GetParameterAsFloat(D_SPREAD) + 1.0;
         delayRight.level = 1.0 - GetParameterAsFloat(D_SPREAD);
 
@@ -462,8 +465,6 @@ void ReverbDelayModule::ProcessStereo(float inL, float inR) {
     // Do the base stereo calculation (which resets the right signal to be the inputR instead of combined mono)
     BaseEffectModule::ProcessStereo(inL, inR);
 
-    ProcessModulation();
-
     // Calculate the effect
     float timeParam = GetParameterAsFloat(DELAY_TIME);
 
@@ -482,7 +483,7 @@ void ReverbDelayModule::ProcessStereo(float inL, float inR) {
     delayLeft.dual_delay = GetParameterAsBool(DUAL_DELAY);
     delayRight.dual_delay = GetParameterAsBool(DUAL_DELAY);
 
-    if (GetParameterAsFloat(DUAL_DELAY)) { // If dual delay is turned on, spread controls the L/R panning of the two delays
+    if (GetParameterAsBool(DUAL_DELAY)) { // If dual delay is turned on, spread controls the L/R panning of the two delays
         delayLeft.level = GetParameterAsFloat(D_SPREAD) + 1.0;
         delayRight.level = 1.0 - GetParameterAsFloat(D_SPREAD);
 

--- a/Software/GuitarPedal/Effect-Modules/spectral_delay_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/spectral_delay_module.cpp
@@ -1,6 +1,8 @@
 #include "spectral_delay_module.h"
 #include "../Util/audio_utilities.h"
+#include <algorithm>
 #include <array>
+#include <cstring>
 
 using namespace bkshepherd;
 
@@ -178,6 +180,13 @@ SpectralDelayModule::~SpectralDelayModule() {
 void SpectralDelayModule::Init(float sample_rate) {
     BaseEffectModule::Init(sample_rate);
 
+    // SDRAM is not zeroed at startup; clear the STFT buffers so the first
+    // frames don't transform random memory (which can push NaN into the
+    // feedback delay lines and stick there)
+    memset(in, 0, sizeof(in));
+    memset(middle, 0, sizeof(middle));
+    memset(out, 0, sizeof(out));
+
     // initialize FFT and STFT objects
     fft = new ShyFFT<float, N, RotationPhasor>();
     fft->Init();
@@ -249,8 +258,10 @@ void SpectralDelayModule::ParameterChanged(int parameter_id) // Somewhere here i
                 delay_array_real[i].feedback = delay_array_imag[i].feedback = r;
 
             } else if (delay_fdbk_mode == 1) {
+                // (sin + 1) can reach 2x the knob value; clamp so per-bin
+                // feedback never exceeds 1.0 (unbounded growth otherwise)
                 delay_array_real[i].feedback = delay_array_imag[i].feedback =
-                    (sin((i * cycles / delay_array_size) * 2 * PI) + 1.0) * vdelay_fdbk;
+                    std::min(1.0f, static_cast<float>((sin((i * cycles / delay_array_size) * 2 * PI) + 1.0) * vdelay_fdbk));
 
             } else if (delay_fdbk_mode == 2) {
                 delay_array_real[i].feedback = delay_array_imag[i].feedback = vdelay_fdbk * i / delay_array_size;

--- a/Software/GuitarPedal/Effect-Modules/tuner_module.cpp
+++ b/Software/GuitarPedal/Effect-Modules/tuner_module.cpp
@@ -74,6 +74,9 @@ void TunerModule::ProcessMono(float in) {
 
     if (!m_muteOutput) {
         m_audioLeft = m_audioRight = in;
+    } else {
+        // Output silence rather than holding the last unmuted sample as DC
+        m_audioLeft = m_audioRight = 0.0f;
     }
 }
 

--- a/Software/GuitarPedal/UI/guitar_pedal_ui.h
+++ b/Software/GuitarPedal/UI/guitar_pedal_ui.h
@@ -63,7 +63,7 @@ class GuitarPedalUI {
     UiEventQueue m_eventQueue;
 
     bool m_needToCloseActiveEffectSettingsMenu;
-    float m_secondsTilReturnFromParamChange;
+    float m_secondsTilReturnFromParamChange = 0.0f;
     int m_paramIdToReturnTo;
 
     AbstractMenu::ItemConfig m_mainMenuItems[kNumMainMenuItems];
@@ -71,16 +71,18 @@ class GuitarPedalUI {
     AbstractMenu::ItemConfig m_presetsMenuItems[kNumPresetSettingsItems];
     int m_numActiveEffectSettingsItems;
     uint32_t m_activePresetSelected;
-    AbstractMenu::ItemConfig *m_activeEffectSettingsMenuItems;
+    // These are tested against nullptr and deleted before reallocation, so
+    // they must start out null even for non-static instances
+    AbstractMenu::ItemConfig *m_activeEffectSettingsMenuItems = nullptr;
     EffectModuleMenuItem m_effectModuleMenuItem;
 
-    const char **m_availableEffectNames;
-    MappedStringListValue *m_availableEffectListMappedValues;
-    MappedIntValue **m_activeEffectSettingIntValues;
+    const char **m_availableEffectNames = nullptr;
+    MappedStringListValue *m_availableEffectListMappedValues = nullptr;
+    MappedIntValue **m_activeEffectSettingIntValues = nullptr;
     MappedIntValue m_activePresetSettingIntValue;
-    MappedStringListValue **m_activeEffectSettingStringValues;
-    MyMappedFloatValue **m_activeEffectSettingFloatValues;
-    bool *m_activeEffectSettingBoolValues;
+    MappedStringListValue **m_activeEffectSettingStringValues = nullptr;
+    MyMappedFloatValue **m_activeEffectSettingFloatValues = nullptr;
+    bool *m_activeEffectSettingBoolValues = nullptr;
     MappedIntValue m_midiChannelSettingValue;
 
     bool m_displayingSaveSettingsNotification;

--- a/Software/GuitarPedal/Util/audio_utilities.cpp
+++ b/Software/GuitarPedal/Util/audio_utilities.cpp
@@ -4,6 +4,18 @@ float tempo_to_freq(uint32_t tempo) { return static_cast<float>(tempo) / 60.0f; 
 
 uint32_t freq_to_tempo(float freq) { return freq * 60.0f; }
 
-uint32_t ms_to_tempo(uint32_t ms) { return 60000 / ms; }
+uint32_t ms_to_tempo(uint32_t ms) {
+    if (ms == 0) {
+        return 0;
+    }
+    return 60000 / ms;
+}
 
-uint32_t s_to_tempo(float seconds) { return 60 / seconds; }
+uint32_t s_to_tempo(float seconds) {
+    // Guard division by zero; the inf would be undefined behavior when
+    // converted to uint32_t. Callers clamp the returned BPM to their range.
+    if (seconds <= 0.0f) {
+        return 0;
+    }
+    return 60 / seconds;
+}

--- a/Software/GuitarPedal/Util/granularplayermod.cpp
+++ b/Software/GuitarPedal/Util/granularplayermod.cpp
@@ -1,4 +1,5 @@
 #include "granularplayermod.h"
+#include <algorithm>
 
 using namespace daisysp;
 
@@ -62,10 +63,13 @@ void GranularPlayerMod::Init(float *sample, int size, float sample_rate, float p
 
 uint32_t GranularPlayerMod::WrapIdx(uint32_t idx, uint32_t sz) {
     /*wraps idx to sz*/
-    // TODO verify change >= from just =
+    if (sz == 0) {
+        return 0;
+    }
+    // The index can exceed sz by more than one full length (long grains plus
+    // the random width offset), so a single subtraction isn't enough
     if (idx >= sz) {
-        idx = idx - sz;
-        return idx;
+        idx %= sz;
     }
 
     return idx;
@@ -118,7 +122,8 @@ void GranularPlayerMod::setEnvelopeMode(int env_mode) { env_mode_ = env_mode; }
 void GranularPlayerMod::setStereoSpread(float spread) { spread_ = spread; }
 
 void GranularPlayerMod::setSampleSize(float sample_size) {
-    variable_size_ = sample_size;
+    // Guard against a zero size (division by zero below)
+    variable_size_ = std::max(sample_size, 1.0f);
     sample_frequency_ = sample_rate_ / variable_size_;
 }
 
@@ -143,8 +148,19 @@ void GranularPlayerMod::Process(float speed, float transposition, float grain_si
     idxSpeed2_ = NegativeInvert(&phs2_, speed_) * variable_size_;
     idxTransp_ = (NegativeInvert(&phsImp_, transposition_) * MsToSamps(grain_size_, sample_rate_));
     idxTransp2_ = (NegativeInvert(&phsImp2_, transposition_) * MsToSamps(grain_size_, sample_rate_));
-    idx_ = WrapIdx((uint32_t)(idxSpeed_ + idxTransp_ + rand_idx_mod_), variable_size_);
-    idx2_ = WrapIdx((uint32_t)(idxSpeed2_ + idxTransp2_ + rand_idx_mod2_), variable_size_);
+    // The random width offset can make the position negative; wrap it back
+    // into range before the unsigned conversion (negative float to unsigned
+    // is undefined behavior)
+    float idxFloat = idxSpeed_ + idxTransp_ + rand_idx_mod_;
+    float idxFloat2 = idxSpeed2_ + idxTransp2_ + rand_idx_mod2_;
+    if (idxFloat < 0.0f) {
+        idxFloat += variable_size_;
+    }
+    if (idxFloat2 < 0.0f) {
+        idxFloat2 += variable_size_;
+    }
+    idx_ = WrapIdx((uint32_t)std::max(idxFloat, 0.0f), variable_size_);
+    idx2_ = WrapIdx((uint32_t)std::max(idxFloat2, 0.0f), variable_size_);
 
     // Check for when phase output equals 0.0, then generate a new random index modifier for next grain envelope
     float phase_out1_imp = phsImp_.Process();
@@ -164,20 +180,25 @@ void GranularPlayerMod::Process(float speed, float transposition, float grain_si
     if (phase_out2_imp > 0.9)
         switch2 = true;
 
+    // The phasor can return exactly 1.0, which would index one past the end
+    // of the 512-entry envelope tables, so clamp to the last entry
+    const uint32_t envIdx1 = std::min((uint32_t)(phase_out1_imp * 512), (uint32_t)511);
+    const uint32_t envIdx2 = std::min((uint32_t)(phase_out2_imp * 512), (uint32_t)511);
+
     if (env_mode_ == 0) {
 
-        sig_ = sample_[idx_] * cosEnv_[(uint32_t)(phase_out1_imp * 512)];
-        sig2_ = sample_[idx2_] * cosEnv_[(uint32_t)(phase_out2_imp * 512)];
+        sig_ = sample_[idx_] * cosEnv_[envIdx1];
+        sig2_ = sample_[idx2_] * cosEnv_[envIdx2];
 
     } else if (env_mode_ == 1) {
 
-        sig_ = sample_[idx_] * linEnv_[(uint32_t)(phase_out1_imp * 512)];
-        sig2_ = sample_[idx2_] * linEnv_[(uint32_t)(phase_out2_imp * 512)];
+        sig_ = sample_[idx_] * linEnv_[envIdx1];
+        sig2_ = sample_[idx2_] * linEnv_[envIdx2];
 
     } else if (env_mode_ == 2) {
 
-        sig_ = sample_[idx_] * adLinEnv_[(uint32_t)(phase_out1_imp * 512)];
-        sig2_ = sample_[idx2_] * adLinEnv_[(uint32_t)(phase_out2_imp * 512)];
+        sig_ = sample_[idx_] * adLinEnv_[envIdx1];
+        sig2_ = sample_[idx2_] * adLinEnv_[envIdx2];
     }
 
     outl_ = (sig_ * (1.0 - grain_pan1_) + sig2_ * (1.0 - grain_pan2_)) / 2;

--- a/Software/GuitarPedal/Util/operator.cpp
+++ b/Software/GuitarPedal/Util/operator.cpp
@@ -20,6 +20,10 @@ void Operator::Init(float samplerate, bool isCarrier) {
     iscarrier_ = isCarrier;
 
     modval_ = 0.0;
+
+    // Used in Process() before the first note-on, so it must not be garbage
+    velocity_ = 0.0f;
+    velocity_amp_ = 0.0f;
 }
 
 float Operator::Process() {

--- a/Software/GuitarPedal/Util/pitch_shifter.h
+++ b/Software/GuitarPedal/Util/pitch_shifter.h
@@ -67,6 +67,14 @@ class PitchShifter {
         force_recalc_ = false;
         sr_ = sr;
         mod_freq_ = 5.0f;
+        transpose_ = 0.0f;
+        mod_a_amt_ = mod_b_amt_ = 0.0f;
+        prev_phs_a_ = prev_phs_b_ = 0.0f;
+        for (uint8_t i = 0; i < 2; i++) {
+            slewed_mod_[i] = 0.0f;
+            mod_coeff_[i] = 0.0002f;
+            mod_[i] = 0.0f;
+        }
 
         d_[0].Init(bufferA, buffer_size);
         d_[1].Init(bufferB, buffer_size);
@@ -142,7 +150,9 @@ class PitchShifter {
         float ratio;
         if (transpose_ != transpose || force_recalc_) {
             transpose_ = quantize_semitones_ ? (int32_t)transpose : transpose;
-            ratio = pow(2.f, transpose_ / 12.f);
+            // exp2f keeps this single-precision; this runs per-sample during
+            // momentary ramps and double-precision pow is software-emulated
+            ratio = exp2f(transpose_ * (1.f / 12.f));
             mod_freq_ = ((ratio - 1.0f) * sr_) / del_size_;
             phs_[0].SetFreq(mod_freq_);
             phs_[1].SetFreq(mod_freq_);

--- a/Software/GuitarPedal/guitar_pedal.cpp
+++ b/Software/GuitarPedal/guitar_pedal.cpp
@@ -115,6 +115,13 @@ int crossFaderTransitionTimeInSamples;
 int samplesTilCrossFadingComplete;
 CpuLoadMeter cpuLoadMeter;
 
+// Effect switch requested from the audio callback (interrupt context).
+// Switching effects rebuilds the UI menus with heap new/delete, which is not
+// safe from the interrupt (allocator reentrancy, and the main loop may be
+// iterating those menu allocations), so the request is deferred to the main
+// loop. -1 means no switch is pending.
+volatile int pendingEffectIDFromAudioCallback = -1;
+
 void SetActiveEffect(int effectID);
 
 static void AudioCallback(AudioHandle::InputBuffer in, AudioHandle::OutputBuffer out, size_t size) {
@@ -211,26 +218,27 @@ static void AudioCallback(AudioHandle::InputBuffer in, AudioHandle::OutputBuffer
             !ignoreBypassSwitchUntilNextActuation) {
 
             // If we have a screen and there is a tuner module, we quick switch
-            // to it, otherwise we just cycle through the effects
-            if (hardware.SupportsDisplay() && tunerModuleIndex > 0) {
+            // to it, otherwise we just cycle through the effects.
+            // The actual switch is deferred to the main loop (it isn't safe
+            // from this interrupt); SetActiveEffect syncs the new effect's
+            // enabled state with effectOn when the switch is applied.
+            if (hardware.SupportsDisplay() && tunerModuleIndex >= 0) {
                 // Start the quick switch to the tuner
                 if (activeEffectID == tunerModuleIndex) {
                     // Set back the active effect before the quick switch
-                    SetActiveEffect(prevActiveEffectID);
+                    pendingEffectIDFromAudioCallback = prevActiveEffectID;
 
                     // Restore the effect state from when we quick switched, this is an
                     // inverse because the act of holding the switch caused the state to
                     // chnage due to the rising edge being detected
                     effectOn = !effectActiveBeforeQuickSwitch;
-                    activeEffect->SetEnabled(effectOn);
                 } else {
                     // Store if effect is on or not when quick switching
                     effectActiveBeforeQuickSwitch = effectOn;
 
                     // Switch to tuner and force it to be enabled
-                    SetActiveEffect(tunerModuleIndex);
+                    pendingEffectIDFromAudioCallback = tunerModuleIndex;
                     effectOn = true;
-                    activeEffect->SetEnabled(effectOn);
                 }
                 ignoreBypassSwitchUntilNextActuation = true;
             } else {
@@ -246,10 +254,9 @@ static void AudioCallback(AudioHandle::InputBuffer in, AudioHandle::OutputBuffer
                     newActiveEffectId = 0;
                 }
 
-                SetActiveEffect(newActiveEffectId);
+                pendingEffectIDFromAudioCallback = newActiveEffectId;
 
                 effectOn = false;
-                activeEffect->SetEnabled(effectOn);
 
                 ignoreBypassSwitchUntilNextActuation = true;
             }
@@ -469,6 +476,11 @@ void SetActiveEffect(int effectID) {
         // Update the Active Effect directly.
         activeEffect = availableEffects[effectID];
 
+        // Keep the new effect's enabled state in sync with the global bypass
+        // state (previously only the footswitch paths did this, leaving menu
+        // and MIDI program-change switches with stale LED/enabled state)
+        activeEffect->SetEnabled(effectOn);
+
         guitarPedalUI.UpdateActiveEffect(effectID);
 
         // Get a handle to the persitance storage settings
@@ -663,6 +675,16 @@ int main(void) {
         lastTimeStampUS = currentTimeStampUS;
         float elapsedTimeInSeconds = (elapsedTimeStampUS / 1000000.0f);
         secondsSinceStartup = secondsSinceStartup + elapsedTimeInSeconds;
+
+        // Apply any effect switch requested by the audio callback. Doing it
+        // here (instead of in the interrupt) keeps the UI menu heap
+        // allocations off the audio interrupt. This must run before the menu
+        // sync below so the menu reflects the switch instead of undoing it.
+        if (pendingEffectIDFromAudioCallback >= 0) {
+            int pendingID = pendingEffectIDFromAudioCallback;
+            pendingEffectIDFromAudioCallback = -1;
+            SetActiveEffect(pendingID);
+        }
 
         // Handle Knob Changes
         if (!knobValuesInitialized && secondsSinceStartup > 1.0f) {

--- a/Software/GuitarPedal/guitar_pedal_storage.cpp
+++ b/Software/GuitarPedal/guitar_pedal_storage.cpp
@@ -123,7 +123,7 @@ uint32_t ShiftSettingsToMatchCurrentParameters(uint32_t prev_params, uint32_t cu
     Settings &settings = storage.GetSettings();
 
     newMaxIdx += presetsCount * (curr_params - prev_params);
-    if (newMaxIdx <= SETTINGS_ABSOLUTE_MAX_PARAM_COUNT) {
+    if (newMaxIdx < SETTINGS_ABSOLUTE_MAX_PARAM_COUNT) {
         if (curr_params > prev_params) {
             uint32_t diff = newMaxIdx - currentMaxIdx;
             for (uint32_t i = newMaxIdx; i >= shiftStartIdx; --i) {
@@ -151,7 +151,7 @@ uint32_t ShiftSettingsToAddNewPreset(int effectID, uint32_t params, uint32_t shi
     Settings &settings = storage.GetSettings();
 
     newMaxIdx += params;
-    if (newMaxIdx <= SETTINGS_ABSOLUTE_MAX_PARAM_COUNT) {
+    if (newMaxIdx < SETTINGS_ABSOLUTE_MAX_PARAM_COUNT) {
         uint32_t diff = newMaxIdx - currentMaxIdx;
         for (uint32_t i = newMaxIdx; i >= shiftStartIdx; --i) {
             settings.globalEffectsSettings[i] = settings.globalEffectsSettings[i - diff];
@@ -198,6 +198,11 @@ void LoadEffectSettingsFromPersistantStorage() {
     // Load Preset 0 of each Effect Parameters, based on values from Persistant Storage
     for (int effectID = 0; effectID < availableEffectsCount; effectID++) {
         uint32_t presetsCount = settings.globalEffectsSettings[globalEffectsSettingMemIdx];
+        // Sanity check against corrupt flash: a presetsCount of 0 would
+        // underflow (presetsCount - 1U) below and index far out of bounds
+        if (presetsCount == 0 || presetsCount > SETTINGS_ABSOLUTE_MAX_PARAM_COUNT) {
+            presetsCount = 1;
+        }
         availableEffects[effectID]->SetSettingsArrayStartIdx(globalEffectsSettingMemIdx);
         ++globalEffectsSettingMemIdx;
         uint32_t paramCount = availableEffects[effectID]->GetParameterCount();


### PR DESCRIPTION
Extremely AI assisted. A few pretty valid bugs, especially the polyoctave parameters/knob swap regression.

Pitch shifter:
- ~~Output dry signal in momentary mode when released; the 0-semitone wet path froze the LFO phasors at an arbitrary phase, comb filtering the signal at a level that varied with every release~~ Reverted this, it was done by choice to avoid clicking sound at transition
- Use exp2f instead of double-precision pow in SetTransposition, which runs per-sample during momentary ramps
- Initialize all PitchShifter DSP members in Init (previously safe only because the instance was static)
- Derive ramp transition times from the actual sample rate

Core/framework:
- Defer effect switching requested from the audio interrupt to the main loop; it rebuilt UI menus with heap new/delete from the ISR (allocator reentrancy + use-after-free race with the main loop)
- Sync the new effect's enabled state in SetActiveEffect so menu and MIDI program-change switches don't leave stale bypass/LED state
- Fix off-by-one bounds checks in the settings shift helpers that could write one word past globalEffectsSettings
- Guard against presetsCount == 0 from corrupt flash underflowing into a huge settings index
- Fix || vs && in Get/SetParameterAsFloat bounds checks
- Clamp full-scale binned magnitudes so MIDI CC 127 selects the last bin instead of being silently ignored
- Allow tuner quick-switch when the tuner is effect index 0

Modules:
- polyoctave: unswap the 1-oct-down and 2-oct-down level knobs
- multi_delay: use stored semitone values directly (they were rescaled through -12..12 twice), handle DELAY_TAP_3/4 parameter changes, move TAP_MODE off colliding knob/CC mappings, clamp follower tap targets to the delay buffer
- distortion: replace per-sample std::vector allocations in the oversampling path with a fixed stack buffer
- delay, reverb_delay, granulardelay, pluckecho, autopan, noise_gate: initialize smoothing state used by fonepole before first use (a NaN bit pattern in uninitialized memory never converges)
- spectral_delay: zero SDRAM STFT buffers in Init, clamp sine-mode per-bin feedback to 1.0
- reverb_delay: drop duplicate ProcessModulation call in ProcessStereo, use GetParameterAsBool for the DUAL_DELAY bool param
- crusher: initialize the pitch detector at Init instead of allocating lazily in the audio callback; fix BITS default raw value (31 = bin 32)
- midi_keys: right channel no longer includes the left dry signal twice
- tuner: output silence when muted instead of holding the last sample
- delay: make the DelayPan mod target reachable (was gated on an impossible bin value)
- metro: tap tempo updates the stored/displayed TEMPO parameter

Util:
- granularplayermod: clamp envelope table index (phasor can return exactly 1.0), wrap indices larger than 2x the sample size, avoid negative-float-to-unsigned conversion, guard setSampleSize(0)
- audio_utilities: guard division by zero in ms_to_tempo/s_to_tempo
- operator: initialize velocity members used before the first note-on
- guitar_pedal_ui: null-initialize menu allocation pointers